### PR TITLE
#11 Feature: 셀러 마이페이지 아이템 상세정보 관련 API 구현

### DIFF
--- a/src/main/java/com/influy/domain/category/entity/CategoryInitializer.java
+++ b/src/main/java/com/influy/domain/category/entity/CategoryInitializer.java
@@ -1,0 +1,48 @@
+package com.influy.domain.category.entity;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.influy.domain.category.repository.CategoryRepository;
+import com.influy.global.apiPayload.code.status.ErrorStatus;
+import com.influy.global.apiPayload.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class CategoryInitializer implements CommandLineRunner {
+    private final CategoryRepository categoryRepository;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void run(String... args) throws Exception {
+        if (categoryRepository.count() == 0) {
+            // JAR 내부 classpath에서 JSON 파일 로드
+            try (InputStream inputStream = getClass().getClassLoader()
+                    .getResourceAsStream("category-storage/category.json")) {
+
+                if (inputStream == null) {
+                    throw new IOException("category.json 파일을 찾을 수 없습니다.");
+                }
+
+                // JSON 파일을 Java 객체(List<Category>)로 변환
+                List<Category> categoryList = objectMapper.readValue(
+                        inputStream,
+                        new TypeReference<List<Category>>() {}
+                );
+
+                // DB에 저장
+                categoryRepository.saveAll(categoryList);
+
+            } catch (IOException e) {
+                throw new RuntimeException("JSON 파일 로드 중 오류 발생: " + e.getMessage(), e);
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/influy/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/influy/domain/category/repository/CategoryRepository.java
@@ -1,0 +1,10 @@
+package com.influy.domain.category.repository;
+
+import com.influy.domain.category.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+    Optional<Category> findByCategory(String category);
+}

--- a/src/main/java/com/influy/domain/faqCategory/entity/FaqCategory.java
+++ b/src/main/java/com/influy/domain/faqCategory/entity/FaqCategory.java
@@ -25,7 +25,7 @@ public class FaqCategory extends BaseEntity {
 
     private String category;
 
-    private Integer order;
+    private Integer categoryOrder;
 
     @OneToMany(mappedBy = "faqCategory", cascade = CascadeType.ALL)
     @Builder.Default

--- a/src/main/java/com/influy/domain/image/converter/ImageConverter.java
+++ b/src/main/java/com/influy/domain/image/converter/ImageConverter.java
@@ -1,0 +1,14 @@
+package com.influy.domain.image.converter;
+
+import com.influy.domain.image.entity.Image;
+import com.influy.domain.item.entity.Item;
+
+public class ImageConverter {
+    public static Image toImage(Item item, String imgLink, Boolean isMainImg) {
+        return Image.builder()
+                .item(item)
+                .imageLink(imgLink)
+                .isMainImg(isMainImg)
+                .build();
+    }
+}

--- a/src/main/java/com/influy/domain/image/entity/Image.java
+++ b/src/main/java/com/influy/domain/image/entity/Image.java
@@ -18,7 +18,7 @@ public class Image extends BaseEntity {
     @JoinColumn(name = "item_id")
     private Item item;
 
-    private String imageUrl;
+    private String imageLink;
 
     @Builder.Default
     private Boolean isMainImg = false;

--- a/src/main/java/com/influy/domain/item/controller/ItemRestController.java
+++ b/src/main/java/com/influy/domain/item/controller/ItemRestController.java
@@ -30,9 +30,10 @@ public class ItemRestController {
     }
 
     @GetMapping
-    @Operation(summary = "셀러의 상품 상세정보 프리뷰 리스트 조회")
-    public ApiResponse<ItemResponseDto.DetailPreviewListDto> getDetailPreviewList(@PathVariable("sellerId") Long sellerId) {
-        List<Item> itemList = itemService.getDetailPreviewList(sellerId);
+    @Operation(summary = "셀러의 상품 상세정보 프리뷰 리스트 조회 (공개/아카이브 여부 선택 가능)")
+    public ApiResponse<ItemResponseDto.DetailPreviewListDto> getDetailPreviewList(@PathVariable("sellerId") Long sellerId,
+                                                                                  @RequestParam(name = "archive", defaultValue = "false") Boolean isArchived) {
+        List<Item> itemList = itemService.getDetailPreviewList(sellerId, isArchived);
         return ApiResponse.onSuccess(ItemConverter.toDetailPreviewListDto(itemList));
     }
 
@@ -79,10 +80,11 @@ public class ItemRestController {
         return ApiResponse.onSuccess(ItemConverter.toResultDto(item));
     }
 
-    @GetMapping("/archive")
-    @Operation(summary = "셀러 상품 보관 리스트 조회")
-    public ApiResponse<ItemResponseDto.DetailPreviewListDto> getArchivedDetailPreviewList(@PathVariable("sellerId") Long sellerId) {
-        List<Item> archivedItemList = itemService.getArchivedDetailPreviewList(sellerId);
-        return ApiResponse.onSuccess(ItemConverter.toDetailPreviewListDto(archivedItemList));
+    @GetMapping("/count")
+    @Operation(summary = "상품 공개/보관 개수 조회")
+    public ApiResponse<ItemResponseDto.CountDto> getCount(@PathVariable("sellerId") Long sellerId,
+                                                          @RequestParam(name = "isArchived", defaultValue = "false") Boolean isArchived) {
+        Integer count = itemService.getCount(sellerId, isArchived);
+        return ApiResponse.onSuccess(ItemConverter.toCountDto(sellerId, count));
     }
 }

--- a/src/main/java/com/influy/domain/item/controller/ItemRestController.java
+++ b/src/main/java/com/influy/domain/item/controller/ItemRestController.java
@@ -5,14 +5,15 @@ import com.influy.domain.item.dto.ItemRequestDto;
 import com.influy.domain.item.dto.ItemResponseDto;
 import com.influy.domain.item.entity.Item;
 import com.influy.domain.item.service.ItemService;
+import com.influy.domain.seller.entity.ItemSortType;
 import com.influy.global.apiPayload.ApiResponse;
+import com.influy.global.validation.annotation.CheckPage;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @Tag(name = "셀러 아이템", description = "셀러 아이템 관련 API")
 @RestController
@@ -31,10 +32,13 @@ public class ItemRestController {
 
     @GetMapping
     @Operation(summary = "셀러의 상품 상세정보 프리뷰 리스트 조회 (공개/아카이브 여부 선택 가능)")
-    public ApiResponse<ItemResponseDto.DetailPreviewListDto> getDetailPreviewList(@PathVariable("sellerId") Long sellerId,
-                                                                                  @RequestParam(name = "archive", defaultValue = "false") Boolean isArchived) {
-        List<Item> itemList = itemService.getDetailPreviewList(sellerId, isArchived);
-        return ApiResponse.onSuccess(ItemConverter.toDetailPreviewListDto(itemList));
+    public ApiResponse<ItemResponseDto.DetailPreviewPageDto> getDetailPreviewPage(@PathVariable("sellerId") Long sellerId,
+                                                                                  @RequestParam(name = "archive", defaultValue = "false") Boolean isArchived,
+                                                                                  @CheckPage @RequestParam(name = "page") Integer page,
+                                                                                  @RequestParam(name = "sortType", defaultValue = "END_DATE") ItemSortType sortType) {
+        Integer pageNumber = page - 1;
+        Page<Item> itemPage = itemService.getDetailPreviewPage(sellerId, isArchived, pageNumber, sortType);
+        return ApiResponse.onSuccess(ItemConverter.toDetailPreviewPageDto(itemPage));
     }
 
     @GetMapping("/{itemId}")

--- a/src/main/java/com/influy/domain/item/controller/ItemRestController.java
+++ b/src/main/java/com/influy/domain/item/controller/ItemRestController.java
@@ -1,0 +1,88 @@
+package com.influy.domain.item.controller;
+
+import com.influy.domain.item.converter.ItemConverter;
+import com.influy.domain.item.dto.ItemRequestDto;
+import com.influy.domain.item.dto.ItemResponseDto;
+import com.influy.domain.item.entity.Item;
+import com.influy.domain.item.service.ItemService;
+import com.influy.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "셀러 아이템", description = "셀러 아이템 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/seller/{sellerId}/items")
+public class ItemRestController {
+    private final ItemService itemService;
+
+    @PostMapping
+    @Operation(summary = "셀러 상품 상세정보 작성 후 생성")
+    public ApiResponse<ItemResponseDto.ResultDto> createItem(@PathVariable("sellerId") Long sellerId,
+                                                             @RequestBody @Valid ItemRequestDto.DetailDto request) {
+        Item item = itemService.createItem(sellerId, request);
+        return ApiResponse.onSuccess(ItemConverter.toResultDto(item));
+    }
+
+    @GetMapping
+    @Operation(summary = "셀러의 상품 상세정보 프리뷰 리스트 조회")
+    public ApiResponse<ItemResponseDto.DetailPreviewListDto> getDetailPreviewList(@PathVariable("sellerId") Long sellerId) {
+        List<Item> itemList = itemService.getDetailPreviewList(sellerId);
+        return ApiResponse.onSuccess(ItemConverter.toDetailPreviewListDto(itemList));
+    }
+
+    @GetMapping("/{itemId}")
+    @Operation(summary = "개별 상품 상세정보 조회")
+    public ApiResponse<ItemResponseDto.DetailViewDto> getDetail(@PathVariable("sellerId") Long sellerId,
+                                                                @PathVariable("itemId") Long itemId) {
+        Item item = itemService.getDetail(sellerId, itemId);
+        return ApiResponse.onSuccess(ItemConverter.toDetailViewDto(item));
+    }
+
+    @DeleteMapping("/{itemId}")
+    @Operation(summary = "개별 상품 삭제")
+    public ApiResponse<ItemResponseDto.ResultDto> deleteItem(@PathVariable("sellerId") Long sellerId,
+                                                             @PathVariable("itemId") Long itemId) {
+        itemService.deleteItem(sellerId, itemId);
+        return ApiResponse.onSuccess(ItemConverter.toResultDto(itemId));
+    }
+
+    @PutMapping("/{itemId}")
+    @Operation(summary = "개별 상품 상세정보 수정")
+    public ApiResponse<ItemResponseDto.DetailViewDto> updateItem(@PathVariable("sellerId") Long sellerId,
+                                                                 @PathVariable("itemId") Long itemId,
+                                                                 @RequestBody @Valid ItemRequestDto.DetailDto request) {
+        Item item = itemService.updateItem(sellerId, itemId, request);
+        return ApiResponse.onSuccess(ItemConverter.toDetailViewDto(item));
+    }
+
+    @PatchMapping("/{itemId}/access")
+    @Operation(summary = "개별 상품 공개 범위 설정")
+    public ApiResponse<ItemResponseDto.ResultDto> setAccess(@PathVariable("sellerId") Long sellerId,
+                                                            @PathVariable("itemId") Long itemId,
+                                                            @RequestBody @Valid ItemRequestDto.AccessDto request) {
+        Item item = itemService.setAccess(sellerId, itemId, request);
+        return ApiResponse.onSuccess(ItemConverter.toResultDto(item));
+    }
+
+    @PatchMapping("/{itemId}/status")
+    @Operation(summary = "개별 상품 표기 상태 설정")
+    public ApiResponse<ItemResponseDto.ResultDto> setStatus(@PathVariable("sellerId") Long sellerId,
+                                                            @PathVariable("itemId") Long itemId,
+                                                            @RequestBody @Valid ItemRequestDto.StatusDto request) {
+        Item item = itemService.setStatus(sellerId, itemId, request);
+        return ApiResponse.onSuccess(ItemConverter.toResultDto(item));
+    }
+
+    @GetMapping("/archive")
+    @Operation(summary = "셀러 상품 보관 리스트 조회")
+    public ApiResponse<ItemResponseDto.DetailPreviewListDto> getArchivedDetailPreviewList(@PathVariable("sellerId") Long sellerId) {
+        List<Item> archivedItemList = itemService.getArchivedDetailPreviewList(sellerId);
+        return ApiResponse.onSuccess(ItemConverter.toDetailPreviewListDto(archivedItemList));
+    }
+}

--- a/src/main/java/com/influy/domain/item/converter/ItemConverter.java
+++ b/src/main/java/com/influy/domain/item/converter/ItemConverter.java
@@ -5,6 +5,7 @@ import com.influy.domain.item.dto.ItemResponseDto;
 import com.influy.domain.item.entity.Item;
 import com.influy.domain.image.entity.Image;
 import com.influy.domain.seller.entity.Seller;
+import org.springframework.data.domain.Page;
 
 import java.util.List;
 
@@ -51,14 +52,18 @@ public class ItemConverter {
                 .build();
     }
 
-    public static ItemResponseDto.DetailPreviewListDto toDetailPreviewListDto(List<Item> itemList) {
-        List<ItemResponseDto.DetailPreviewDto> itemPreviewList = itemList.stream()
+    public static ItemResponseDto.DetailPreviewPageDto toDetailPreviewPageDto(Page<Item> itemPage) {
+        List<ItemResponseDto.DetailPreviewDto> itemPreviewList = itemPage.stream()
                 .map(ItemConverter::toDetailPreviewDto)
                 .toList();
 
-        return ItemResponseDto.DetailPreviewListDto.builder()
+        return ItemResponseDto.DetailPreviewPageDto.builder()
                 .itemPreviewList(itemPreviewList)
-                .totalElements(itemList.size())
+                .listSize(itemPage.getContent().size())
+                .totalPage(itemPage.getTotalPages())
+                .totalElements(itemPage.getTotalElements())
+                .isFirst(itemPage.isFirst())
+                .isLast(itemPage.isLast())
                 .build();
     }
 

--- a/src/main/java/com/influy/domain/item/converter/ItemConverter.java
+++ b/src/main/java/com/influy/domain/item/converter/ItemConverter.java
@@ -84,4 +84,11 @@ public class ItemConverter {
                 .itemCategoryList(itemCategoryList)
                 .build();
     }
+
+    public static ItemResponseDto.CountDto toCountDto(Long sellerId, Integer count) {
+       return ItemResponseDto.CountDto.builder()
+               .sellerId(sellerId)
+               .count(count)
+               .build();
+    }
 }

--- a/src/main/java/com/influy/domain/item/converter/ItemConverter.java
+++ b/src/main/java/com/influy/domain/item/converter/ItemConverter.java
@@ -1,0 +1,87 @@
+package com.influy.domain.item.converter;
+
+import com.influy.domain.item.dto.ItemRequestDto;
+import com.influy.domain.item.dto.ItemResponseDto;
+import com.influy.domain.item.entity.Item;
+import com.influy.domain.image.entity.Image;
+import com.influy.domain.seller.entity.Seller;
+
+import java.util.List;
+
+public class ItemConverter {
+    public static Item toItem(Seller seller, ItemRequestDto.DetailDto request) {
+        return Item.builder()
+                .seller(seller)
+                .name(request.getName())
+                .regularPrice(request.getRegularPrice())
+                .salePrice(request.getSalePrice())
+                .tagline(request.getTagline())
+                .startDate(request.getStartDate())
+                .endDate(request.getEndDate())
+                .itemPeriod(request.getItemPeriod())
+                .marketLink(request.getMarketLink())
+                .comment(request.getComment())
+                .isArchived(request.getIsArchived())
+                .build();
+    }
+
+    public static ItemResponseDto.ResultDto toResultDto(Item item) {
+        return ItemResponseDto.ResultDto.builder()
+                .itemId(item.getId())
+                .build();
+    }
+
+    public static ItemResponseDto.ResultDto toResultDto(Long itemId) {
+        return ItemResponseDto.ResultDto.builder()
+                .itemId(itemId)
+                .build();
+    }
+
+    public static ItemResponseDto.DetailPreviewDto toDetailPreviewDto(Item item) {
+        return ItemResponseDto.DetailPreviewDto.builder()
+                .itemId(item.getId())
+                .MainImg(item.getImageList().get(0).getImageLink())
+                .itemPeriod(item.getItemPeriod())
+                .itemName(item.getName())
+                .sellerName(item.getSeller().getNickname())
+                .startDate(item.getStartDate())
+                .endDate(item.getEndDate())
+                .tagline(item.getTagline())
+                .currentStatus(item.getItemStatus())
+                .build();
+    }
+
+    public static ItemResponseDto.DetailPreviewListDto toDetailPreviewListDto(List<Item> itemList) {
+        List<ItemResponseDto.DetailPreviewDto> itemPreviewList = itemList.stream()
+                .map(ItemConverter::toDetailPreviewDto)
+                .toList();
+
+        return ItemResponseDto.DetailPreviewListDto.builder()
+                .itemPreviewList(itemPreviewList)
+                .totalElements(itemList.size())
+                .build();
+    }
+
+    public static ItemResponseDto.DetailViewDto toDetailViewDto(Item item) {
+        List<String> itemImgLinkList = item.getImageList().stream()
+                .map(Image::getImageLink).toList();
+
+        List<String> itemCategoryList = item.getItemCategoryList().stream()
+                .map(ic -> ic.getCategory().getCategory())
+                .toList();
+
+        return ItemResponseDto.DetailViewDto.builder()
+                .itemId(item.getId())
+                .itemPeriod(item.getItemPeriod())
+                .itemName(item.getName())
+                .startDate(item.getStartDate())
+                .endDate(item.getEndDate())
+                .tagline(item.getTagline())
+                .currentStatus(item.getItemStatus())
+                .marketLink(item.getMarketLink())
+                .isArchived(item.getIsArchived())
+                .itemImgList(itemImgLinkList)
+                .itemCategoryList(itemCategoryList)
+                .build();
+    }
+}

--- a/src/main/java/com/influy/domain/item/dto/ItemRequestDto.java
+++ b/src/main/java/com/influy/domain/item/dto/ItemRequestDto.java
@@ -1,0 +1,80 @@
+package com.influy.domain.item.dto;
+
+import com.influy.domain.item.entity.ItemStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class ItemRequestDto {
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DetailDto {
+        @Schema(description = "아이템 사진 리스트, 대표사진은 리스트 맨 처음 순서로", example = "[xxx.png, xxxxx.png, xxxxxx.png]")
+        @Size(max = 10, message = "이미지는 최대 10개까지만 업로드할 수 있습니다.")
+        private List<String> itemImgList;
+
+        @Schema(description = "아이템 제목", example = "제작 원피스")
+        private String name;
+
+        @Schema(description = "아이템 카테고리, 1~3개", example = "[뷰티, 패션, 소품]")
+        @Size(max = 3, message = "카테고리는 최대 3개까지만 업로드할 수 있습니다.")
+        private List<String> itemCategoryList;
+
+        @Schema(description = "시작일", example = "021-01-01T00:00")
+        private LocalDateTime startDate;
+
+        @Schema(description = "마감일", example = "021-01-01T00:00")
+        private LocalDateTime endDate;
+
+        @Schema(description = "한줄 소개", example = "빤짝거리는 원피스입니다")
+        private String tagline;
+
+        @Schema(description = "정가", example = "100000")
+        private Long regularPrice;
+
+        @Schema(description = "할인가", example = "80000")
+        private Long salePrice;
+
+        @Schema(description = "판매 링크", example = "xxxx.com")
+        private String marketLink;
+
+        @Schema(description = "진행 회차", example = "1")
+        private Integer itemPeriod;
+
+        @Schema(description = "코멘트", example = "이렇게 빤짝이는 드레스 흔하지 않아요 어렵게 구해왔어요")
+        private String comment;
+
+        @Schema(description = "보관 여부 (보관: true, 게시: false)", example = "false")
+        private Boolean isArchived;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AccessDto {
+        @Schema(description = "홈아카이브 추천 허용", example = "false")
+        private Boolean archiveRecommended;
+
+        @Schema(description = "서비스 내 검색 허용", example = "false")
+        private Boolean searchAvailable;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class StatusDto {
+        @Schema(description = "아이템 표기 상태", example = "SOLD_OUT")
+        private ItemStatus status;
+    }
+}

--- a/src/main/java/com/influy/domain/item/dto/ItemResponseDto.java
+++ b/src/main/java/com/influy/domain/item/dto/ItemResponseDto.java
@@ -1,0 +1,108 @@
+package com.influy.domain.item.dto;
+
+import com.influy.domain.image.entity.Image;
+import com.influy.domain.item.entity.ItemStatus;
+import com.influy.domain.itemCategory.entity.ItemCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class ItemResponseDto {
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class ResultDto {
+        @Schema(description = "아이템 id", example = "1")
+        private Long itemId;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DetailPreviewDto {
+        @Schema(description = "아이템 id", example = "1")
+        private Long itemId;
+
+        @Schema(description = "대표 사진", example = "xxxx.png")
+        private String MainImg;
+
+        @Schema(description = "진행 차수", example = "1")
+        private Integer itemPeriod;
+
+        @Schema(description = "아이템 이름", example = "원피스")
+        private String itemName;
+
+        @Schema(description = "셀러 이름", example = "소현소현")
+        private String sellerName;
+
+        @Schema(description = "시작일", example = "021-01-01T00:00")
+        private LocalDateTime startDate;
+
+        @Schema(description = "마감일", example = "021-01-01T00:00")
+        private LocalDateTime endDate;
+
+        @Schema(description = "한줄 소개", example = "빤짝거리는 원피스입니다")
+        private String tagline;
+
+        @Schema(description = "아이템 상태", example = "DEFAULT")
+        private ItemStatus currentStatus;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DetailPreviewListDto {
+        @Schema(description = "아이템 preview 리스트")
+        private List<DetailPreviewDto> itemPreviewList;
+
+        @Schema(description = "아이템 총 개수", example = "15")
+        private Integer totalElements;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DetailViewDto {
+        @Schema(description = "아이템 id", example = "1")
+        private Long itemId;
+
+        @Schema(description = "진행 차수", example = "1")
+        private Integer itemPeriod;
+
+        @Schema(description = "아이템 이름", example = "원피스")
+        private String itemName;
+
+        @Schema(description = "시작일", example = "021-01-01T00:00")
+        private LocalDateTime startDate;
+
+        @Schema(description = "마감일", example = "021-01-01T00:00")
+        private LocalDateTime endDate;
+
+        @Schema(description = "한줄 소개", example = "빤짝거리는 원피스입니다")
+        private String tagline;
+
+        @Schema(description = "아이템 상태", example = "DEFAULT")
+        private ItemStatus currentStatus;
+
+        @Schema(description = "판매 링크", example = "xxxx.com")
+        private String marketLink;
+
+        @Schema(description = "보관 여부 (보관: true, 게시: false)", example = "false")
+        private Boolean isArchived;
+
+        @Schema(description = "아이템 사진 리스트, 대표사진은 리스트 맨 처음 순서로", example = "[xxx.png, xxxxx.png, xxxxxx.png]")
+        private List<String> itemImgList;
+
+        @Schema(description = "아이템 카테고리, 1~3개", example = "[뷰티, 패션, 소품]")
+        private List<String> itemCategoryList;
+    }
+}

--- a/src/main/java/com/influy/domain/item/dto/ItemResponseDto.java
+++ b/src/main/java/com/influy/domain/item/dto/ItemResponseDto.java
@@ -1,8 +1,6 @@
 package com.influy.domain.item.dto;
 
-import com.influy.domain.image.entity.Image;
 import com.influy.domain.item.entity.ItemStatus;
-import com.influy.domain.itemCategory.entity.ItemCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -59,13 +57,17 @@ public class ItemResponseDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class DetailPreviewListDto {
+    public static class DetailPreviewPageDto {
         @Schema(description = "아이템 preview 리스트")
         private List<DetailPreviewDto> itemPreviewList;
 
-        @Schema(description = "아이템 총 개수", example = "15")
-        private Integer totalElements;
+        private Integer listSize;
+        private Integer totalPage;
+        private Long totalElements;
+        private Boolean isFirst;
+        private Boolean isLast;
     }
+
 
     @Getter
     @Builder

--- a/src/main/java/com/influy/domain/item/dto/ItemResponseDto.java
+++ b/src/main/java/com/influy/domain/item/dto/ItemResponseDto.java
@@ -105,4 +105,16 @@ public class ItemResponseDto {
         @Schema(description = "아이템 카테고리, 1~3개", example = "[뷰티, 패션, 소품]")
         private List<String> itemCategoryList;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CountDto {
+        @Schema(description = "셀러 id", example = "1")
+        private Long sellerId;
+
+        @Schema(description = "공개/보관 아이템 개수", example = "5")
+        private Integer count;
+    }
 }

--- a/src/main/java/com/influy/domain/item/entity/Item.java
+++ b/src/main/java/com/influy/domain/item/entity/Item.java
@@ -1,19 +1,24 @@
 package com.influy.domain.item.entity;
 
 import com.influy.domain.faqCategory.entity.FaqCategory;
+import com.influy.domain.image.entity.Image;
 import com.influy.domain.itemCategory.entity.ItemCategory;
+import com.influy.domain.questionCategory.entity.QuestionCategory;
 import com.influy.domain.seller.entity.Seller;
 import com.influy.global.common.BaseEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.*;
+import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
+@Setter
 @Builder
 @Getter
 @AllArgsConstructor
@@ -29,16 +34,16 @@ public class Item extends BaseEntity {
     @NotBlank
     private String name;
 
-    @NotBlank
-    private Integer regularPrice;
+    private Long regularPrice;
 
-    @NotBlank
-    private Integer salePrice;
+    private Long salePrice;
 
     private String tagline;
 
+    @NotNull
     private LocalDateTime startDate;
 
+    @NotNull
     private LocalDateTime endDate;
 
     @Builder.Default
@@ -52,10 +57,10 @@ public class Item extends BaseEntity {
 
     @Builder.Default
     @Enumerated(EnumType.STRING)
-    private ItemStatus currentStatus = ItemStatus.DEFAULT;  //표기 상태: [기본, 완판]
+    private ItemStatus itemStatus = ItemStatus.DEFAULT;  //표기 상태: [기본, 완판]
 
     @NotBlank
-    private String marketUrl;
+    private String marketLink;
 
     private String comment;
 
@@ -66,8 +71,16 @@ public class Item extends BaseEntity {
     @Builder.Default
     private List<FaqCategory> faqCategoryList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "item", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "item", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<ItemCategory> itemCategoryList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "item", cascade = CascadeType.ALL)
+    @Builder.Default
+    private List<QuestionCategory> questionCategoryList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "item", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<Image> imageList = new ArrayList<>();
 
 }

--- a/src/main/java/com/influy/domain/item/repository/ItemRepository.java
+++ b/src/main/java/com/influy/domain/item/repository/ItemRepository.java
@@ -1,13 +1,15 @@
 package com.influy.domain.item.repository;
 
 import com.influy.domain.item.entity.Item;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface ItemRepository extends JpaRepository<Item, Long> {
-    List<Item> findBySellerIdAndIsArchivedTrueOrderByCreatedAtDesc(Long sellerId);
-    List<Item> findBySellerIdAndIsArchivedFalseOrderByCreatedAtDesc(Long sellerId);
     Integer countBySellerIdAndIsArchivedTrue(Long sellerId);
     Integer countBySellerIdAndIsArchivedFalse(Long sellerId);
+    Page<Item> findBySellerIdAndIsArchivedTrue(Long sellerId, Pageable pageable);
+    Page<Item> findBySellerIdAndIsArchivedFalse(Long sellerId, Pageable pageable);
 }

--- a/src/main/java/com/influy/domain/item/repository/ItemRepository.java
+++ b/src/main/java/com/influy/domain/item/repository/ItemRepository.java
@@ -1,0 +1,11 @@
+package com.influy.domain.item.repository;
+
+import com.influy.domain.item.entity.Item;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ItemRepository extends JpaRepository<Item, Long> {
+    List<Item> findBySellerIdOrderByCreatedAtDesc(Long sellerId);
+    List<Item> findBySellerIdAndIsArchivedTrueOrderByCreatedAtDesc(Long sellerId);
+}

--- a/src/main/java/com/influy/domain/item/repository/ItemRepository.java
+++ b/src/main/java/com/influy/domain/item/repository/ItemRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface ItemRepository extends JpaRepository<Item, Long> {
-    List<Item> findBySellerIdOrderByCreatedAtDesc(Long sellerId);
     List<Item> findBySellerIdAndIsArchivedTrueOrderByCreatedAtDesc(Long sellerId);
+    List<Item> findBySellerIdAndIsArchivedFalseOrderByCreatedAtDesc(Long sellerId);
+    Integer countBySellerIdAndIsArchivedTrue(Long sellerId);
+    Integer countBySellerIdAndIsArchivedFalse(Long sellerId);
 }

--- a/src/main/java/com/influy/domain/item/service/ItemService.java
+++ b/src/main/java/com/influy/domain/item/service/ItemService.java
@@ -1,0 +1,18 @@
+package com.influy.domain.item.service;
+
+import com.influy.domain.item.dto.ItemRequestDto;
+import com.influy.domain.item.entity.Item;
+import jakarta.validation.Valid;
+
+import java.util.List;
+
+public interface ItemService {
+    Item createItem(Long sellerId, ItemRequestDto.DetailDto request);
+    List<Item> getDetailPreviewList(Long sellerId);
+    Item getDetail(Long sellerId, Long itemId);
+    void deleteItem(Long sellerId, Long itemId);
+    Item updateItem(Long sellerId, Long itemId, ItemRequestDto.DetailDto request);
+    Item setAccess(Long sellerId, Long itemId, ItemRequestDto.AccessDto request);
+    Item setStatus(Long sellerId, Long itemId, ItemRequestDto.StatusDto request);
+    List<Item> getArchivedDetailPreviewList(Long sellerId);
+}

--- a/src/main/java/com/influy/domain/item/service/ItemService.java
+++ b/src/main/java/com/influy/domain/item/service/ItemService.java
@@ -2,17 +2,19 @@ package com.influy.domain.item.service;
 
 import com.influy.domain.item.dto.ItemRequestDto;
 import com.influy.domain.item.entity.Item;
+import com.influy.domain.seller.entity.ItemSortType;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
 
 import java.util.List;
 
 public interface ItemService {
     Item createItem(Long sellerId, ItemRequestDto.DetailDto request);
-    List<Item> getDetailPreviewList(Long sellerId, Boolean isArchived);
     Item getDetail(Long sellerId, Long itemId);
     void deleteItem(Long sellerId, Long itemId);
     Item updateItem(Long sellerId, Long itemId, ItemRequestDto.DetailDto request);
     Item setAccess(Long sellerId, Long itemId, ItemRequestDto.AccessDto request);
     Item setStatus(Long sellerId, Long itemId, ItemRequestDto.StatusDto request);
     Integer getCount(Long sellerId, Boolean isArchived);
+    Page<Item> getDetailPreviewPage(Long sellerId, Boolean isArchived, Integer pageNumber, ItemSortType sortType);
 }

--- a/src/main/java/com/influy/domain/item/service/ItemService.java
+++ b/src/main/java/com/influy/domain/item/service/ItemService.java
@@ -8,11 +8,11 @@ import java.util.List;
 
 public interface ItemService {
     Item createItem(Long sellerId, ItemRequestDto.DetailDto request);
-    List<Item> getDetailPreviewList(Long sellerId);
+    List<Item> getDetailPreviewList(Long sellerId, Boolean isArchived);
     Item getDetail(Long sellerId, Long itemId);
     void deleteItem(Long sellerId, Long itemId);
     Item updateItem(Long sellerId, Long itemId, ItemRequestDto.DetailDto request);
     Item setAccess(Long sellerId, Long itemId, ItemRequestDto.AccessDto request);
     Item setStatus(Long sellerId, Long itemId, ItemRequestDto.StatusDto request);
-    List<Item> getArchivedDetailPreviewList(Long sellerId);
+    Integer getCount(Long sellerId, Boolean isArchived);
 }

--- a/src/main/java/com/influy/domain/item/service/ItemServiceImpl.java
+++ b/src/main/java/com/influy/domain/item/service/ItemServiceImpl.java
@@ -1,0 +1,178 @@
+package com.influy.domain.item.service;
+
+import com.influy.domain.category.entity.Category;
+import com.influy.domain.category.repository.CategoryRepository;
+import com.influy.domain.image.converter.ImageConverter;
+import com.influy.domain.image.entity.Image;
+import com.influy.domain.item.converter.ItemConverter;
+import com.influy.domain.item.dto.ItemRequestDto;
+import com.influy.domain.item.entity.Item;
+import com.influy.domain.item.repository.ItemRepository;
+import com.influy.domain.itemCategory.converter.ItemCategoryConverter;
+import com.influy.domain.itemCategory.entity.ItemCategory;
+import com.influy.domain.seller.entity.Seller;
+import com.influy.domain.seller.repository.SellerRepository;
+import com.influy.global.apiPayload.code.status.ErrorStatus;
+import com.influy.global.apiPayload.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ItemServiceImpl implements ItemService {
+    private final SellerRepository sellerRepository;
+    private final CategoryRepository categoryRepository;
+    private final ItemRepository itemRepository;
+
+    @Override
+    @Transactional
+    public Item createItem(Long sellerId, ItemRequestDto.DetailDto request) {
+        Seller seller = sellerRepository.findById(sellerId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.SELLER_NOT_FOUND));
+
+        Item item = ItemConverter.toItem(seller, request);
+        item = itemRepository.save(item);
+
+        createImageList(request, item);
+        createItemCategoryList(request, item);
+
+        seller.getItemList().add(item);
+
+        return item;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<Item> getDetailPreviewList(Long sellerId) {
+        if (!sellerRepository.existsById(sellerId)) {
+            throw new GeneralException(ErrorStatus.SELLER_NOT_FOUND);
+        }
+
+        return itemRepository.findBySellerIdOrderByCreatedAtDesc(sellerId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Item getDetail(Long sellerId, Long itemId) {
+        if (!sellerRepository.existsById(sellerId)) {
+            throw new GeneralException(ErrorStatus.SELLER_NOT_FOUND);
+        }
+
+        return itemRepository.findById(itemId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.ITEM_NOT_FOUND));
+    }
+
+    @Override
+    @Transactional
+    public void deleteItem(Long sellerId, Long itemId) {
+        if (!sellerRepository.existsById(sellerId)) {
+            throw new GeneralException(ErrorStatus.SELLER_NOT_FOUND);
+        }
+
+        Item item = itemRepository.findById(itemId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.ITEM_NOT_FOUND));
+
+        itemRepository.delete(item);
+    }
+
+    @Override
+    @Transactional
+    public Item updateItem(Long sellerId, Long itemId, ItemRequestDto.DetailDto request) {
+        if (!sellerRepository.existsById(sellerId)) {
+            throw new GeneralException(ErrorStatus.SELLER_NOT_FOUND);
+        }
+
+        Item item = itemRepository.findById(itemId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.ITEM_NOT_FOUND));
+
+        if (request.getName() != null) item.setName(request.getName());
+        if (request.getStartDate() != null) item.setStartDate(request.getStartDate());
+        if (request.getEndDate() != null) item.setEndDate(request.getEndDate());
+        if (request.getTagline() != null) item.setTagline(request.getTagline());
+        if (request.getRegularPrice() != null) item.setRegularPrice(request.getRegularPrice());
+        if (request.getSalePrice() != null) item.setSalePrice(request.getSalePrice());
+        if (request.getMarketLink() != null) item.setMarketLink(request.getMarketLink());
+        if (request.getItemPeriod() != null) item.setItemPeriod(request.getItemPeriod());
+        if (request.getComment() != null) item.setComment(request.getComment());
+        if (request.getIsArchived() != null) item.setIsArchived(request.getIsArchived());
+
+        if (request.getItemImgList() != null) {
+            item.getImageList().clear();
+            createImageList(request, item);
+        }
+
+        if (request.getItemCategoryList() != null) {
+            item.getItemCategoryList().clear();
+            createItemCategoryList(request, item);
+        }
+
+        return item;
+    }
+
+    @Override
+    @Transactional
+    public Item setAccess(Long sellerId, Long itemId, ItemRequestDto.AccessDto request) {
+        if (!sellerRepository.existsById(sellerId)) {
+            throw new GeneralException(ErrorStatus.SELLER_NOT_FOUND);
+        }
+
+        Item item = itemRepository.findById(itemId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.ITEM_NOT_FOUND));
+
+        if (request.getArchiveRecommended() != null) item.setArchiveRecommended(request.getArchiveRecommended());
+        if (request.getSearchAvailable() != null) item.setSearchAvailable(request.getSearchAvailable());
+
+        return item;
+    }
+
+    @Override
+    @Transactional
+    public Item setStatus(Long sellerId, Long itemId, ItemRequestDto.StatusDto request) {
+        if (!sellerRepository.existsById(sellerId)) {
+            throw new GeneralException(ErrorStatus.SELLER_NOT_FOUND);
+        }
+
+        Item item = itemRepository.findById(itemId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.ITEM_NOT_FOUND));
+
+        if (request.getStatus() != null) item.setItemStatus(request.getStatus());
+
+        return item;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<Item> getArchivedDetailPreviewList(Long sellerId) {
+        if (!sellerRepository.existsById(sellerId)) {
+            throw new GeneralException(ErrorStatus.SELLER_NOT_FOUND);
+        }
+
+        return itemRepository.findBySellerIdAndIsArchivedTrueOrderByCreatedAtDesc(sellerId);
+    }
+
+    private void createImageList(ItemRequestDto.DetailDto request, Item item) {
+        List<String> imageLinkList = request.getItemImgList();
+        for (int i = 0; i < imageLinkList.size(); i++) {
+            boolean isMain = (i == 0);
+            Image image = ImageConverter.toImage(item, imageLinkList.get(i), isMain);
+            item.getImageList().add(image);
+        }
+    }
+
+    private void createItemCategoryList(ItemRequestDto.DetailDto request, Item item) {
+        List<String> itemCategoryStrList = request.getItemCategoryList();
+        for (String str : itemCategoryStrList) {
+            Category category = categoryRepository.findByCategory(str)
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.CATEGORY_NOT_FOUND));
+            ItemCategory itemCategory = ItemCategoryConverter.toItemCategory(category, item);
+            category.getItemCategoryList().add(itemCategory);
+            item.getItemCategoryList().add(itemCategory);
+        }
+    }
+
+
+
+}

--- a/src/main/java/com/influy/domain/item/service/ItemServiceImpl.java
+++ b/src/main/java/com/influy/domain/item/service/ItemServiceImpl.java
@@ -12,6 +12,7 @@ import com.influy.domain.itemCategory.converter.ItemCategoryConverter;
 import com.influy.domain.itemCategory.entity.ItemCategory;
 import com.influy.domain.seller.entity.Seller;
 import com.influy.domain.seller.repository.SellerRepository;
+import com.influy.domain.seller.service.SellerService;
 import com.influy.global.apiPayload.code.status.ErrorStatus;
 import com.influy.global.apiPayload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
@@ -26,12 +27,12 @@ public class ItemServiceImpl implements ItemService {
     private final SellerRepository sellerRepository;
     private final CategoryRepository categoryRepository;
     private final ItemRepository itemRepository;
+    private final SellerService sellerService;
 
     @Override
     @Transactional
     public Item createItem(Long sellerId, ItemRequestDto.DetailDto request) {
-        Seller seller = sellerRepository.findById(sellerId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.SELLER_NOT_FOUND));
+        Seller seller = sellerService.getSeller(sellerId);
 
         Item item = ItemConverter.toItem(seller, request);
         item = itemRepository.save(item);
@@ -47,9 +48,7 @@ public class ItemServiceImpl implements ItemService {
     @Override
     @Transactional(readOnly = true)
     public List<Item> getDetailPreviewList(Long sellerId, Boolean isArchived) {
-        if (!sellerRepository.existsById(sellerId)) {
-            throw new GeneralException(ErrorStatus.SELLER_NOT_FOUND);
-        }
+        sellerService.getSeller(sellerId);
 
         if (isArchived) return itemRepository.findBySellerIdAndIsArchivedTrueOrderByCreatedAtDesc(sellerId);
         else return itemRepository.findBySellerIdAndIsArchivedFalseOrderByCreatedAtDesc(sellerId);
@@ -58,9 +57,7 @@ public class ItemServiceImpl implements ItemService {
     @Override
     @Transactional(readOnly = true)
     public Item getDetail(Long sellerId, Long itemId) {
-        if (!sellerRepository.existsById(sellerId)) {
-            throw new GeneralException(ErrorStatus.SELLER_NOT_FOUND);
-        }
+        sellerService.getSeller(sellerId);
 
         return itemRepository.findById(itemId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.ITEM_NOT_FOUND));
@@ -69,9 +66,7 @@ public class ItemServiceImpl implements ItemService {
     @Override
     @Transactional
     public void deleteItem(Long sellerId, Long itemId) {
-        if (!sellerRepository.existsById(sellerId)) {
-            throw new GeneralException(ErrorStatus.SELLER_NOT_FOUND);
-        }
+        sellerService.getSeller(sellerId);
 
         Item item = itemRepository.findById(itemId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.ITEM_NOT_FOUND));
@@ -82,9 +77,7 @@ public class ItemServiceImpl implements ItemService {
     @Override
     @Transactional
     public Item updateItem(Long sellerId, Long itemId, ItemRequestDto.DetailDto request) {
-        if (!sellerRepository.existsById(sellerId)) {
-            throw new GeneralException(ErrorStatus.SELLER_NOT_FOUND);
-        }
+        sellerService.getSeller(sellerId);
 
         Item item = itemRepository.findById(itemId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.ITEM_NOT_FOUND));
@@ -116,9 +109,7 @@ public class ItemServiceImpl implements ItemService {
     @Override
     @Transactional
     public Item setAccess(Long sellerId, Long itemId, ItemRequestDto.AccessDto request) {
-        if (!sellerRepository.existsById(sellerId)) {
-            throw new GeneralException(ErrorStatus.SELLER_NOT_FOUND);
-        }
+        sellerService.getSeller(sellerId);
 
         Item item = itemRepository.findById(itemId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.ITEM_NOT_FOUND));
@@ -132,9 +123,7 @@ public class ItemServiceImpl implements ItemService {
     @Override
     @Transactional
     public Item setStatus(Long sellerId, Long itemId, ItemRequestDto.StatusDto request) {
-        if (!sellerRepository.existsById(sellerId)) {
-            throw new GeneralException(ErrorStatus.SELLER_NOT_FOUND);
-        }
+        sellerService.getSeller(sellerId);
 
         Item item = itemRepository.findById(itemId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.ITEM_NOT_FOUND));
@@ -147,9 +136,7 @@ public class ItemServiceImpl implements ItemService {
     @Override
     @Transactional(readOnly = true)
     public Integer getCount(Long sellerId, Boolean isArchived) {
-        if (!sellerRepository.existsById(sellerId)) {
-            throw new GeneralException(ErrorStatus.SELLER_NOT_FOUND);
-        }
+        sellerService.getSeller(sellerId);
 
         if (isArchived) return itemRepository.countBySellerIdAndIsArchivedTrue(sellerId);
         else return itemRepository.countBySellerIdAndIsArchivedFalse(sellerId);

--- a/src/main/java/com/influy/domain/item/service/ItemServiceImpl.java
+++ b/src/main/java/com/influy/domain/item/service/ItemServiceImpl.java
@@ -46,12 +46,13 @@ public class ItemServiceImpl implements ItemService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<Item> getDetailPreviewList(Long sellerId) {
+    public List<Item> getDetailPreviewList(Long sellerId, Boolean isArchived) {
         if (!sellerRepository.existsById(sellerId)) {
             throw new GeneralException(ErrorStatus.SELLER_NOT_FOUND);
         }
 
-        return itemRepository.findBySellerIdOrderByCreatedAtDesc(sellerId);
+        if (isArchived) return itemRepository.findBySellerIdAndIsArchivedTrueOrderByCreatedAtDesc(sellerId);
+        else return itemRepository.findBySellerIdAndIsArchivedFalseOrderByCreatedAtDesc(sellerId);
     }
 
     @Override
@@ -145,12 +146,13 @@ public class ItemServiceImpl implements ItemService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<Item> getArchivedDetailPreviewList(Long sellerId) {
+    public Integer getCount(Long sellerId, Boolean isArchived) {
         if (!sellerRepository.existsById(sellerId)) {
             throw new GeneralException(ErrorStatus.SELLER_NOT_FOUND);
         }
 
-        return itemRepository.findBySellerIdAndIsArchivedTrueOrderByCreatedAtDesc(sellerId);
+        if (isArchived) return itemRepository.countBySellerIdAndIsArchivedTrue(sellerId);
+        else return itemRepository.countBySellerIdAndIsArchivedFalse(sellerId);
     }
 
     private void createImageList(ItemRequestDto.DetailDto request, Item item) {

--- a/src/main/java/com/influy/domain/itemCategory/converter/ItemCategoryConverter.java
+++ b/src/main/java/com/influy/domain/itemCategory/converter/ItemCategoryConverter.java
@@ -1,0 +1,14 @@
+package com.influy.domain.itemCategory.converter;
+
+import com.influy.domain.category.entity.Category;
+import com.influy.domain.item.entity.Item;
+import com.influy.domain.itemCategory.entity.ItemCategory;
+
+public class ItemCategoryConverter {
+    public static ItemCategory toItemCategory(Category category, Item item) {
+        return ItemCategory.builder()
+                .item(item)
+                .category(category)
+                .build();
+    }
+}

--- a/src/main/java/com/influy/domain/questionCategory/entity/QuestionCategory.java
+++ b/src/main/java/com/influy/domain/questionCategory/entity/QuestionCategory.java
@@ -27,8 +27,6 @@ public class QuestionCategory extends BaseEntity {
     @NotBlank
     private String category;
 
-    private Integer order;
-
     @OneToMany(mappedBy = "questionCategory", cascade = CascadeType.ALL)
     @Builder.Default
     private List<Question> questionList = new ArrayList<>();

--- a/src/main/java/com/influy/domain/seller/entity/Seller.java
+++ b/src/main/java/com/influy/domain/seller/entity/Seller.java
@@ -46,7 +46,7 @@ public class Seller extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @Builder.Default
-    private ItemSortType itemSortType = ItemSortType.CREATE_DATE;
+    private ItemSortType itemSortType = ItemSortType.END_DATE;
 
     @OneToMany(mappedBy = "seller", cascade = CascadeType.ALL)
     @Builder.Default
@@ -96,9 +96,9 @@ public class Seller extends BaseEntity {
         if(requestBody.getEmail()!=null){
             this.email = requestBody.getEmail();
         }
-        if(requestBody.getItemSortType()!=null){
-            this.itemSortType = requestBody.getItemSortType();
-        }
+//        if(requestBody.getItemSortType()!=null){
+//            this.itemSortType = requestBody.getItemSortType();
+//        }
         if(requestBody.getIsPublic()!=null){
             this.isPublic = requestBody.getIsPublic();
         }

--- a/src/main/java/com/influy/domain/seller/repository/SellerRepository.java
+++ b/src/main/java/com/influy/domain/seller/repository/SellerRepository.java
@@ -1,0 +1,10 @@
+package com.influy.domain.seller.repository;
+
+import com.influy.domain.seller.entity.Seller;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface SellerRepository extends JpaRepository<Seller, Long> {
+    Optional<Seller> findById(Long id);
+}

--- a/src/main/java/com/influy/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/influy/global/apiPayload/code/status/ErrorStatus.java
@@ -23,7 +23,10 @@ public enum ErrorStatus implements BaseCode {
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "CATEGORY NOT FOUND", "카테고리를 찾을 수 없습니다."),
 
     // 아이템 관련 응답
-    ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "ITEM NOT FOUND", "아이템을 찾을 수 없습니다.");
+    ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "ITEM NOT FOUND", "아이템을 찾을 수 없습니다."),
+
+    // 정렬 관련 응답
+    UNSUPPORTED_SORT_TYPE(HttpStatus.BAD_REQUEST, "UNSUPPORTED SORT TYPE", "가능한 정렬 방식은 CREATE_DATE, END_DATE 입니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/influy/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/influy/global/apiPayload/code/status/ErrorStatus.java
@@ -14,7 +14,20 @@ public enum ErrorStatus implements BaseCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러."),
     BAD_REQUEST(HttpStatus.BAD_REQUEST,"COMMON400","잘못된 요청입니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
-    FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다.");
+    FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+
+    // 셀러 에러 응답
+    SELLER_NOT_FOUND(HttpStatus.NOT_FOUND, "SELLER NOT FOUND", "셀러를 찾을 수 없습니다."),
+
+    // 파일 관련 응답
+    CANNOT_LOCATE_FILE(HttpStatus.NOT_FOUND, "CANNOT LOCATE FILE", "category.json 파일을 찾을 수 없습니다."),
+    CANNOT_LOAD_FILE(HttpStatus.BAD_REQUEST, "CANNOT LOAD FILE", "category.json 파일을 읽을 수 없습니다."),
+
+    // 카테고리 관련 응답
+    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "CATEGORY NOT FOUND", "카테고리를 찾을 수 없습니다."),
+
+    // 아이템 관련 응답
+    ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "ITEM NOT FOUND", "아이템을 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/influy/global/validation/annotation/CheckPage.java
+++ b/src/main/java/com/influy/global/validation/annotation/CheckPage.java
@@ -1,0 +1,17 @@
+package com.influy.global.validation.annotation;
+
+import com.influy.global.validation.validator.PageCheckValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = PageCheckValidator.class)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CheckPage {
+    String message() default "페이지 번호는 1 이상이어야 합니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/influy/global/validation/validator/PageCheckValidator.java
+++ b/src/main/java/com/influy/global/validation/validator/PageCheckValidator.java
@@ -1,0 +1,23 @@
+package com.influy.global.validation.validator;
+
+import com.influy.global.validation.annotation.CheckPage;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class PageCheckValidator implements ConstraintValidator<CheckPage, Integer> {
+    @Override
+    public boolean isValid(Integer page, ConstraintValidatorContext context) {
+        if (page == null || page <= 0) {
+            return false;
+        }
+
+        // 검증을 통과한 경우, 값 조정 (1 -> 0)
+        if (page == 1) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate("페이지 번호를 0으로 변경했습니다.")
+                    .addConstraintViolation();
+        }
+
+        return true;
+    }
+}

--- a/src/main/resources/category-storage/category.json
+++ b/src/main/resources/category-storage/category.json
@@ -1,0 +1,44 @@
+[
+  {
+    "category": "뷰티"
+  },
+  {
+    "category": "패션"
+  },
+  {
+    "category": "푸드"
+  },
+  {
+    "category": "라이프"
+  },
+  {
+    "category": "디지털"
+  },
+  {
+    "category": "패션소품"
+  },
+  {
+    "category": "주얼리"
+  },
+  {
+    "category": "키즈"
+  },
+  {
+    "category": "스포츠/레저"
+  },
+  {
+    "category": "선물"
+  },
+  {
+    "category": "명품"
+  },
+  {
+    "category": "여행"
+  },
+  {
+    "category": "기념일"
+  },
+  {
+    "category": "기타"
+  }
+]


### PR DESCRIPTION
## 💜 Related Issue

> close #11 

## 💜 Work Details

> - [x] 셀러의 상품 생성
> - [x] 셀러의 상품 세부정보 프리뷰 리스트 조회
> - [x] 개별 상품 세부정보 조회
> - [x] 개별 상품 삭제
> - [x] 개별 상품 세부정보 수정
> - [x] 개별 상품 공개 범위 수정
> - [x] 개별 상품 표기 상태 수정
> - [x] 보관된 개별 상품 세부정보 프리뷰 리스트 조회

## 💜 Review Requirement

> 아이템 faq 관련은 아직 구현 안하고 세부정보 관련 사항 api 구현했습니당
> 스웨거 테스트 완료했슴다
> 충돌이 두렵습니다
