### PR TITLE
#17 셀러 공지 관련 API 구현

### DIFF
--- a/src/main/java/com/influy/domain/announcement/controller/AnnouncementController.java
+++ b/src/main/java/com/influy/domain/announcement/controller/AnnouncementController.java
@@ -13,12 +13,14 @@ import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @Tag(name = "공지")
-@RequestMapping("/seller/announcement")
+@RequestMapping("/seller/announcements")
 public class AnnouncementController {
 
     private final AnnouncementService announcementService;
@@ -26,11 +28,22 @@ public class AnnouncementController {
     //공지 리스트 조회
     @GetMapping("/{sellerId}")//로그인 구현 후 id 제거
     @Operation(summary = "공지 리스트 조회",description ="셀러가 본인의 공지 리스트 조회" )
-    public ApiResponse<Page<AnnouncementResponseDTO.General>> getAnnouncements(@PathVariable("sellerId") Long sellerId, @ParameterObject Pageable pageable) {
+    public ApiResponse<Page<AnnouncementResponseDTO.General>> getAnnouncements(@PathVariable("sellerId") Long sellerId, @ParameterObject @PageableDefault(sort="createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
         Page<Announcement> announcements = announcementService.getAnnouncementsOf(sellerId,pageable);
 
         Page<AnnouncementResponseDTO.General> body = announcements.map(AnnouncementConverter::toGeneralDTO);
+
+        return ApiResponse.onSuccess(body);
+    }
+
+    //최상단 공지 조회
+    @GetMapping("/{sellerId}/primary")
+    @Operation(summary = "최상단 공지 조회", description = "최상단 공지가 없으면 가장 최신 등록된 공지 반환")
+    public ApiResponse<AnnouncementResponseDTO.General> getPrimaryAnnouncement(@PathVariable("sellerId") Long sellerId) {
+
+        Announcement announcement = announcementService.getPrimaryAnnouncementOf(sellerId);
+        AnnouncementResponseDTO.General body = AnnouncementConverter.toGeneralDTO(announcement);
 
         return ApiResponse.onSuccess(body);
     }
@@ -58,4 +71,5 @@ public class AnnouncementController {
     }
 
     //
+
 }

--- a/src/main/java/com/influy/domain/announcement/controller/AnnouncementController.java
+++ b/src/main/java/com/influy/domain/announcement/controller/AnnouncementController.java
@@ -1,11 +1,14 @@
 package com.influy.domain.announcement.controller;
 
 import com.influy.domain.announcement.converter.AnnouncementConverter;
+import com.influy.domain.announcement.dto.AnnouncementRequestDTO;
 import com.influy.domain.announcement.dto.AnnouncementResponseDTO;
 import com.influy.domain.announcement.entity.Announcement;
 import com.influy.domain.announcement.service.AnnouncementService;
 import com.influy.domain.seller.entity.Seller;
 import com.influy.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
@@ -14,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "공지")
 @RequestMapping("/seller/announcement")
 public class AnnouncementController {
 
@@ -29,6 +33,16 @@ public class AnnouncementController {
 
         Page<AnnouncementResponseDTO.General> body = announcements.map(AnnouncementConverter::toGeneralDTO);
 
+        return ApiResponse.onSuccess(body);
+    }
+
+    //공지 추가
+    @PostMapping("/{sellerId}") //로그인 구현 후 id 제거
+    @Operation(summary = "공지 추가",description ="셀러가 공지 추가" )
+    public ApiResponse<AnnouncementResponseDTO.General> addAnnouncement(@PathVariable("sellerId") Long sellerId, @RequestBody AnnouncementRequestDTO requestDTO) {
+        Announcement announcement = announcementService.addAnnouncementOf(sellerId,requestDTO);
+
+        AnnouncementResponseDTO.General body = AnnouncementConverter.toGeneralDTO(announcement);
         return ApiResponse.onSuccess(body);
     }
 }

--- a/src/main/java/com/influy/domain/announcement/controller/AnnouncementController.java
+++ b/src/main/java/com/influy/domain/announcement/controller/AnnouncementController.java
@@ -25,11 +25,10 @@ public class AnnouncementController {
 
     //공지 리스트 조회
     @GetMapping("/{sellerId}")//로그인 구현 후 id 제거
+    @Operation(summary = "공지 리스트 조회",description ="셀러가 본인의 공지 리스트 조회" )
     public ApiResponse<Page<AnnouncementResponseDTO.General>> getAnnouncements(@PathVariable("sellerId") Long sellerId, @ParameterObject Pageable pageable) {
 
-        Seller seller = new Seller(2L,"나",true,null,null,null,null,null,
-                "string",null,null,null,null,null,null,null);
-        Page<Announcement> announcements = announcementService.getAnnouncementsOf(seller,pageable);
+        Page<Announcement> announcements = announcementService.getAnnouncementsOf(sellerId,pageable);
 
         Page<AnnouncementResponseDTO.General> body = announcements.map(AnnouncementConverter::toGeneralDTO);
 

--- a/src/main/java/com/influy/domain/announcement/controller/AnnouncementController.java
+++ b/src/main/java/com/influy/domain/announcement/controller/AnnouncementController.java
@@ -38,7 +38,7 @@ public class AnnouncementController {
     }
 
     //최상단 공지 조회
-    @GetMapping("/{sellerId}/primary")
+    @GetMapping("/{sellerId}/primary-announcement")
     @Operation(summary = "최상단 공지 조회", description = "최상단 공지가 없으면 가장 최신 등록된 공지 반환")
     public ApiResponse<AnnouncementResponseDTO.General> getPrimaryAnnouncement(@PathVariable("sellerId") Long sellerId) {
 

--- a/src/main/java/com/influy/domain/announcement/controller/AnnouncementController.java
+++ b/src/main/java/com/influy/domain/announcement/controller/AnnouncementController.java
@@ -1,0 +1,34 @@
+package com.influy.domain.announcement.controller;
+
+import com.influy.domain.announcement.converter.AnnouncementConverter;
+import com.influy.domain.announcement.dto.AnnouncementResponseDTO;
+import com.influy.domain.announcement.entity.Announcement;
+import com.influy.domain.announcement.service.AnnouncementService;
+import com.influy.domain.seller.entity.Seller;
+import com.influy.global.apiPayload.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/seller/announcement")
+public class AnnouncementController {
+
+    private final AnnouncementService announcementService;
+
+    //공지 리스트 조회
+    @GetMapping("/{sellerId}")//로그인 구현 후 id 제거
+    public ApiResponse<Page<AnnouncementResponseDTO.General>> getAnnouncements(@PathVariable("sellerId") Long sellerId, @ParameterObject Pageable pageable) {
+
+        Seller seller = new Seller(2L,"나",true,null,null,null,null,null,
+                "string",null,null,null,null,null,null,null);
+        Page<Announcement> announcements = announcementService.getAnnouncementsOf(seller,pageable);
+
+        Page<AnnouncementResponseDTO.General> body = announcements.map(AnnouncementConverter::toGeneralDTO);
+
+        return ApiResponse.onSuccess(body);
+    }
+}

--- a/src/main/java/com/influy/domain/announcement/controller/AnnouncementController.java
+++ b/src/main/java/com/influy/domain/announcement/controller/AnnouncementController.java
@@ -44,4 +44,16 @@ public class AnnouncementController {
         AnnouncementResponseDTO.General body = AnnouncementConverter.toGeneralDTO(announcement);
         return ApiResponse.onSuccess(body);
     }
+
+    //공지 수정
+    @PatchMapping("/{announcementId}/{sellerId}") //로그인 구현 후 sellerId 제거
+    @Operation(summary = "공지 수정",description ="셀러가 개별 공지 수정" )
+    public ApiResponse<AnnouncementResponseDTO.General> updateAnnouncement(@PathVariable("announcementId") Long announcementId,
+                                                                           @PathVariable("sellerId") Long sellerId,
+                                                                           @RequestBody AnnouncementRequestDTO requestDTO) {
+
+        Announcement announcement = announcementService.updateAnnouncement(announcementId, requestDTO, sellerId);
+        AnnouncementResponseDTO.General body = AnnouncementConverter.toGeneralDTO(announcement);
+        return ApiResponse.onSuccess(body);
+    }
 }

--- a/src/main/java/com/influy/domain/announcement/controller/AnnouncementController.java
+++ b/src/main/java/com/influy/domain/announcement/controller/AnnouncementController.java
@@ -56,4 +56,6 @@ public class AnnouncementController {
         AnnouncementResponseDTO.General body = AnnouncementConverter.toGeneralDTO(announcement);
         return ApiResponse.onSuccess(body);
     }
+
+    //
 }

--- a/src/main/java/com/influy/domain/announcement/controller/AnnouncementController.java
+++ b/src/main/java/com/influy/domain/announcement/controller/AnnouncementController.java
@@ -70,6 +70,16 @@ public class AnnouncementController {
         return ApiResponse.onSuccess(body);
     }
 
-    //
+
+    //공지 삭제
+    @DeleteMapping("/{announcementId}/{sellerId}") //로그인 구현 후 sellerId 제거
+    @Operation(summary = "공지 삭제",description ="셀러가 개별 공지 삭제" )
+    public ApiResponse<String> deleteAnnouncement(@PathVariable("announcementId") Long announcementId,
+                                                  @PathVariable("sellerId") Long sellerId) {
+
+        announcementService.deleteAnnouncement(sellerId, announcementId);
+
+        return ApiResponse.onSuccess("삭제에 성공했습니다.");
+    }
 
 }

--- a/src/main/java/com/influy/domain/announcement/converter/AnnouncementConverter.java
+++ b/src/main/java/com/influy/domain/announcement/converter/AnnouncementConverter.java
@@ -21,6 +21,7 @@ public class AnnouncementConverter {
                 .title(announcement.getTitle())
                 .content(announcement.getContent())
                 .isPrimary(announcement.getIsPrimary())
+                .createdAt(announcement.getCreatedAt())
                 .build();
     }
 }

--- a/src/main/java/com/influy/domain/announcement/converter/AnnouncementConverter.java
+++ b/src/main/java/com/influy/domain/announcement/converter/AnnouncementConverter.java
@@ -1,9 +1,17 @@
 package com.influy.domain.announcement.converter;
 
+import com.influy.domain.announcement.dto.AnnouncementRequestDTO;
 import com.influy.domain.announcement.dto.AnnouncementResponseDTO;
 import com.influy.domain.announcement.entity.Announcement;
 
 public class AnnouncementConverter {
+    public static Announcement toEntity(AnnouncementRequestDTO requestDTO){
+        return Announcement.builder()
+                .title(requestDTO.getTitle())
+                .content(requestDTO.getContent())
+                .build();
+    }
+
     public static AnnouncementResponseDTO.General toGeneralDTO(Announcement announcement) {
 
         return AnnouncementResponseDTO.General.builder()

--- a/src/main/java/com/influy/domain/announcement/converter/AnnouncementConverter.java
+++ b/src/main/java/com/influy/domain/announcement/converter/AnnouncementConverter.java
@@ -3,12 +3,14 @@ package com.influy.domain.announcement.converter;
 import com.influy.domain.announcement.dto.AnnouncementRequestDTO;
 import com.influy.domain.announcement.dto.AnnouncementResponseDTO;
 import com.influy.domain.announcement.entity.Announcement;
+import com.influy.domain.seller.entity.Seller;
 
 public class AnnouncementConverter {
-    public static Announcement toEntity(AnnouncementRequestDTO requestDTO){
+    public static Announcement toEntity(AnnouncementRequestDTO requestDTO, Seller seller){
         return Announcement.builder()
                 .title(requestDTO.getTitle())
                 .content(requestDTO.getContent())
+                .seller(seller)
                 .build();
     }
 

--- a/src/main/java/com/influy/domain/announcement/converter/AnnouncementConverter.java
+++ b/src/main/java/com/influy/domain/announcement/converter/AnnouncementConverter.java
@@ -1,0 +1,16 @@
+package com.influy.domain.announcement.converter;
+
+import com.influy.domain.announcement.dto.AnnouncementResponseDTO;
+import com.influy.domain.announcement.entity.Announcement;
+
+public class AnnouncementConverter {
+    public static AnnouncementResponseDTO.General toGeneralDTO(Announcement announcement) {
+
+        return AnnouncementResponseDTO.General.builder()
+                .id(announcement.getId())
+                .title(announcement.getTitle())
+                .content(announcement.getContent())
+                .isPrimary(announcement.getIsPrimary())
+                .build();
+    }
+}

--- a/src/main/java/com/influy/domain/announcement/converter/AnnouncementConverter.java
+++ b/src/main/java/com/influy/domain/announcement/converter/AnnouncementConverter.java
@@ -11,6 +11,7 @@ public class AnnouncementConverter {
                 .title(requestDTO.getTitle())
                 .content(requestDTO.getContent())
                 .seller(seller)
+                .isPrimary(requestDTO.getIsPrimary())
                 .build();
     }
 

--- a/src/main/java/com/influy/domain/announcement/dto/AnnouncementRequestDTO.java
+++ b/src/main/java/com/influy/domain/announcement/dto/AnnouncementRequestDTO.java
@@ -6,4 +6,5 @@ import lombok.Getter;
 public class AnnouncementRequestDTO {
     private String title;
     private String content;
+    private Boolean isPrimary;
 }

--- a/src/main/java/com/influy/domain/announcement/dto/AnnouncementRequestDTO.java
+++ b/src/main/java/com/influy/domain/announcement/dto/AnnouncementRequestDTO.java
@@ -1,0 +1,9 @@
+package com.influy.domain.announcement.dto;
+
+import lombok.Getter;
+
+@Getter
+public class AnnouncementRequestDTO {
+    private String title;
+    private String content;
+}

--- a/src/main/java/com/influy/domain/announcement/dto/AnnouncementResponseDTO.java
+++ b/src/main/java/com/influy/domain/announcement/dto/AnnouncementResponseDTO.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 public class AnnouncementResponseDTO {
 
     @Getter @Builder
@@ -15,5 +17,6 @@ public class AnnouncementResponseDTO {
         private String title;
         private String content;
         private Boolean isPrimary;
+        private LocalDateTime createdAt;
     }
 }

--- a/src/main/java/com/influy/domain/announcement/dto/AnnouncementResponseDTO.java
+++ b/src/main/java/com/influy/domain/announcement/dto/AnnouncementResponseDTO.java
@@ -1,0 +1,19 @@
+package com.influy.domain.announcement.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class AnnouncementResponseDTO {
+
+    @Getter @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class General{
+        private Long id;
+        private String title;
+        private String content;
+        private Boolean isPrimary;
+    }
+}

--- a/src/main/java/com/influy/domain/announcement/entity/Announcement.java
+++ b/src/main/java/com/influy/domain/announcement/entity/Announcement.java
@@ -37,8 +37,17 @@ public class Announcement extends BaseEntity {
             this.content = requestDTO.getContent();
         }
         if(requestDTO.getIsPrimary() != null){
+
+            if(requestDTO.getIsPrimary()){ //이 공지를 최상단 공지로 등록하는 요청일 경우
+                this.seller.setPrimaryAnnouncement(this); //나로 등록
+            }
             this.isPrimary = requestDTO.getIsPrimary();
         }
+        return this;
+    }
+
+    public Announcement setIsPrimary(Boolean isPrimary) {
+        this.isPrimary = isPrimary;
         return this;
     }
 }

--- a/src/main/java/com/influy/domain/announcement/entity/Announcement.java
+++ b/src/main/java/com/influy/domain/announcement/entity/Announcement.java
@@ -1,5 +1,6 @@
 package com.influy.domain.announcement.entity;
 
+import com.influy.domain.announcement.dto.AnnouncementRequestDTO;
 import com.influy.domain.seller.entity.Seller;
 import com.influy.global.common.BaseEntity;
 import jakarta.persistence.*;
@@ -27,4 +28,14 @@ public class Announcement extends BaseEntity {
 
     @Builder.Default
     private Boolean isPrimary = false;
+
+    public Announcement updateAnnouncement(AnnouncementRequestDTO requestDTO){
+        if(requestDTO.getTitle() != null){
+            this.title = requestDTO.getTitle();
+        }
+        if(requestDTO.getContent() != null){
+            this.content = requestDTO.getContent();
+        }
+        return this;
+    }
 }

--- a/src/main/java/com/influy/domain/announcement/entity/Announcement.java
+++ b/src/main/java/com/influy/domain/announcement/entity/Announcement.java
@@ -36,6 +36,9 @@ public class Announcement extends BaseEntity {
         if(requestDTO.getContent() != null){
             this.content = requestDTO.getContent();
         }
+        if(requestDTO.getIsPrimary() != null){
+            this.isPrimary = requestDTO.getIsPrimary();
+        }
         return this;
     }
 }

--- a/src/main/java/com/influy/domain/announcement/repository/AnnouncementRepository.java
+++ b/src/main/java/com/influy/domain/announcement/repository/AnnouncementRepository.java
@@ -7,7 +7,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface AnnouncementRepository extends JpaRepository<Announcement, Long> {
     Page<Announcement> findAllBySeller(Seller seller, Pageable pageable);
+
+    Optional<Announcement> findFirstBySellerOrderByCreatedAtDesc(Seller seller);
 }

--- a/src/main/java/com/influy/domain/announcement/repository/AnnouncementRepository.java
+++ b/src/main/java/com/influy/domain/announcement/repository/AnnouncementRepository.java
@@ -1,0 +1,13 @@
+package com.influy.domain.announcement.repository;
+
+import com.influy.domain.announcement.entity.Announcement;
+import com.influy.domain.seller.entity.Seller;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AnnouncementRepository extends JpaRepository<Announcement, Long> {
+    Page<Announcement> findAllBySeller(Seller seller, Pageable pageable);
+}

--- a/src/main/java/com/influy/domain/announcement/service/AnnouncementService.java
+++ b/src/main/java/com/influy/domain/announcement/service/AnnouncementService.java
@@ -39,6 +39,9 @@ public class AnnouncementService {
         Seller seller = sellerService.getSeller(sellerId);
 
         Announcement announcement = AnnouncementConverter.toEntity(requestDTO,seller);
+        if(requestDTO.getIsPrimary()){ //이 공지를 최상단 공지로 등록하는 요청일 경우
+            seller.setPrimaryAnnouncement(announcement); //얘로 등록
+        }
         return announcementRepository.save(announcement);
 
     }

--- a/src/main/java/com/influy/domain/announcement/service/AnnouncementService.java
+++ b/src/main/java/com/influy/domain/announcement/service/AnnouncementService.java
@@ -5,6 +5,8 @@ import com.influy.domain.announcement.dto.AnnouncementRequestDTO;
 import com.influy.domain.announcement.entity.Announcement;
 import com.influy.domain.announcement.repository.AnnouncementRepository;
 import com.influy.domain.seller.entity.Seller;
+import com.influy.domain.seller.repository.SellerRepository;
+import com.influy.domain.seller.service.SellerService;
 import com.influy.global.apiPayload.code.status.ErrorStatus;
 import com.influy.global.apiPayload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
@@ -21,20 +23,20 @@ import java.util.Objects;
 public class AnnouncementService {
 
     private final AnnouncementRepository announcementRepository;
+    private final SellerService sellerService;
 
+    //공지 리스트 조회
     public Page<Announcement> getAnnouncementsOf(Long sellerId, Pageable pageable) {
-        //seller 관련 pr 머지되면 셀러 리포지토리에서 existBy로 검증
-        Seller seller = new Seller(sellerId,"나",true,null,null,null,null,null,
-                "string",null,null,null,null,null,null,null);
 
+        Seller seller = sellerService.getSeller(sellerId);
         return announcementRepository.findAllBySeller(seller,pageable);
     }
 
     //공지 추가
     @Transactional
     public Announcement addAnnouncementOf(Long sellerId, AnnouncementRequestDTO requestDTO) {
-        Seller seller = new Seller(sellerId,"나",true,null,null,null,null,null,
-                "string",null,null,null,null,null,null,null);
+
+        Seller seller = sellerService.getSeller(sellerId);
 
         Announcement announcement = AnnouncementConverter.toEntity(requestDTO);
         return announcementRepository.save(announcement);
@@ -42,11 +44,11 @@ public class AnnouncementService {
     }
 
     //특정 공지 수정
+    @Transactional
     public Announcement updateAnnouncement(Long announcementId, AnnouncementRequestDTO requestDTO, Long sellerId) {
 
-        //repo에서 seller 찾아오기
-        Seller seller = new Seller(2L,"나",true,null,null,null,null,null,
-                "string",null,null,null,null,null,null,null);
+
+        Seller seller = sellerService.getSeller(sellerId);
 
         Announcement announcement = announcementRepository.findById(announcementId).orElseThrow(()->new GeneralException(ErrorStatus.ANNOUNCEMENT_NOT_FOUND));
 

--- a/src/main/java/com/influy/domain/announcement/service/AnnouncementService.java
+++ b/src/main/java/com/influy/domain/announcement/service/AnnouncementService.java
@@ -38,7 +38,7 @@ public class AnnouncementService {
 
         Seller seller = sellerService.getSeller(sellerId);
 
-        Announcement announcement = AnnouncementConverter.toEntity(requestDTO);
+        Announcement announcement = AnnouncementConverter.toEntity(requestDTO,seller);
         return announcementRepository.save(announcement);
 
     }
@@ -58,5 +58,20 @@ public class AnnouncementService {
         }
 
         return announcement.updateAnnouncement(requestDTO);
+    }
+
+    //최상단 공지 조회
+    public Announcement getPrimaryAnnouncementOf(Long sellerId) {
+        Seller seller = sellerService.getSeller(sellerId);
+
+        Announcement announcement = seller.getPrimaryAnnouncement();
+
+        if(announcement == null){//최상단 공지가 없으면 가장 최신 공지 제공
+            announcement = announcementRepository.findFirstBySellerOrderByCreatedAtDesc(seller).orElseThrow(
+                    ()-> new GeneralException(ErrorStatus.ANNOUNCEMENT_NOT_FOUND)
+            );
+        }
+
+        return announcement;
     }
 }

--- a/src/main/java/com/influy/domain/announcement/service/AnnouncementService.java
+++ b/src/main/java/com/influy/domain/announcement/service/AnnouncementService.java
@@ -1,5 +1,7 @@
 package com.influy.domain.announcement.service;
 
+import com.influy.domain.announcement.converter.AnnouncementConverter;
+import com.influy.domain.announcement.dto.AnnouncementRequestDTO;
 import com.influy.domain.announcement.entity.Announcement;
 import com.influy.domain.announcement.repository.AnnouncementRepository;
 import com.influy.domain.seller.entity.Seller;
@@ -19,5 +21,16 @@ public class AnnouncementService {
     public Page<Announcement> getAnnouncementsOf(Seller seller, Pageable pageable) {
         //seller 관련 pr 머지되면 셀러 리포지토리에서 existBy로 검증
         return announcementRepository.findAllBySeller(seller,pageable);
+    }
+
+    //공지 추가
+    @Transactional
+    public Announcement addAnnouncementOf(Long sellerId, AnnouncementRequestDTO requestDTO) {
+        Seller seller = new Seller(sellerId,"나",true,null,null,null,null,null,
+                "string",null,null,null,null,null,null,null);
+
+        Announcement announcement = AnnouncementConverter.toEntity(requestDTO);
+        return announcementRepository.save(announcement);
+
     }
 }

--- a/src/main/java/com/influy/domain/announcement/service/AnnouncementService.java
+++ b/src/main/java/com/influy/domain/announcement/service/AnnouncementService.java
@@ -5,11 +5,15 @@ import com.influy.domain.announcement.dto.AnnouncementRequestDTO;
 import com.influy.domain.announcement.entity.Announcement;
 import com.influy.domain.announcement.repository.AnnouncementRepository;
 import com.influy.domain.seller.entity.Seller;
+import com.influy.global.apiPayload.code.status.ErrorStatus;
+import com.influy.global.apiPayload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
 
 @Service
 @Transactional(readOnly = true)
@@ -35,5 +39,22 @@ public class AnnouncementService {
         Announcement announcement = AnnouncementConverter.toEntity(requestDTO);
         return announcementRepository.save(announcement);
 
+    }
+
+    //특정 공지 수정
+    public Announcement updateAnnouncement(Long announcementId, AnnouncementRequestDTO requestDTO, Long sellerId) {
+
+        //repo에서 seller 찾아오기
+        Seller seller = new Seller(2L,"나",true,null,null,null,null,null,
+                "string",null,null,null,null,null,null,null);
+
+        Announcement announcement = announcementRepository.findById(announcementId).orElseThrow(()->new GeneralException(ErrorStatus.ANNOUNCEMENT_NOT_FOUND));
+
+        //작성자가 다를 경우 업데이트 불가
+        if(!announcement.getSeller().equals(seller)){
+            throw new GeneralException(ErrorStatus.UNAUTHORIZED);
+        }
+
+        return announcement.updateAnnouncement(requestDTO);
     }
 }

--- a/src/main/java/com/influy/domain/announcement/service/AnnouncementService.java
+++ b/src/main/java/com/influy/domain/announcement/service/AnnouncementService.java
@@ -1,0 +1,23 @@
+package com.influy.domain.announcement.service;
+
+import com.influy.domain.announcement.entity.Announcement;
+import com.influy.domain.announcement.repository.AnnouncementRepository;
+import com.influy.domain.seller.entity.Seller;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AnnouncementService {
+
+    private final AnnouncementRepository announcementRepository;
+
+    public Page<Announcement> getAnnouncementsOf(Seller seller, Pageable pageable) {
+        //seller 관련 pr 머지되면 셀러 리포지토리에서 existBy로 검증
+        return announcementRepository.findAllBySeller(seller,pageable);
+    }
+}

--- a/src/main/java/com/influy/domain/announcement/service/AnnouncementService.java
+++ b/src/main/java/com/influy/domain/announcement/service/AnnouncementService.java
@@ -74,4 +74,21 @@ public class AnnouncementService {
 
         return announcement;
     }
+
+    @Transactional
+    public void deleteAnnouncement(Long sellerId, Long announcementId) {
+
+        Seller seller = sellerService.getSeller(sellerId);
+
+        Announcement announcement = announcementRepository.findById(announcementId).orElseThrow(()->new GeneralException(ErrorStatus.ANNOUNCEMENT_NOT_FOUND));
+
+        if(!announcement.getSeller().equals(seller)){
+            throw new GeneralException(ErrorStatus.UNAUTHORIZED);
+        }
+        //현재 삭제하려는 공지가 최상단 고정 공지라면 해제를 먼저 해준다
+        if(seller.getPrimaryAnnouncement()==announcement){
+            seller.setPrimaryAnnouncement(null);
+        }
+        announcementRepository.delete(announcement);
+    }
 }

--- a/src/main/java/com/influy/domain/announcement/service/AnnouncementService.java
+++ b/src/main/java/com/influy/domain/announcement/service/AnnouncementService.java
@@ -18,8 +18,11 @@ public class AnnouncementService {
 
     private final AnnouncementRepository announcementRepository;
 
-    public Page<Announcement> getAnnouncementsOf(Seller seller, Pageable pageable) {
+    public Page<Announcement> getAnnouncementsOf(Long sellerId, Pageable pageable) {
         //seller 관련 pr 머지되면 셀러 리포지토리에서 existBy로 검증
+        Seller seller = new Seller(sellerId,"나",true,null,null,null,null,null,
+                "string",null,null,null,null,null,null,null);
+
         return announcementRepository.findAllBySeller(seller,pageable);
     }
 

--- a/src/main/java/com/influy/domain/seller/entity/Seller.java
+++ b/src/main/java/com/influy/domain/seller/entity/Seller.java
@@ -51,6 +51,11 @@ public class Seller extends BaseEntity {
     @Builder.Default
     private List<Announcement> announcementList = new ArrayList<>();
 
+    //삭제하기
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "primary_announcement_id", unique = true)
+    private Announcement primaryAnnouncement;
+
     @OneToMany(mappedBy = "seller", cascade = CascadeType.ALL)
     @Builder.Default
     private List<ProfileLink> profileLinkList = new ArrayList<>();
@@ -104,6 +109,17 @@ public class Seller extends BaseEntity {
 
     public Seller setItemSortType(ItemSortType type){
         this.itemSortType = type;
+        return this;
+    }
+
+    public Seller setPrimaryAnnouncement(Announcement announcement){
+        //기존 최상단 공지와 다른 공지를 등록할 시에 기존 공지 삭제
+        if(this.primaryAnnouncement != null && this.primaryAnnouncement!=announcement){
+            this.primaryAnnouncement.setIsPrimary(false);
+        }
+        //새로 등록
+        this.primaryAnnouncement = announcement;
+        
         return this;
     }
 }

--- a/src/main/java/com/influy/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/influy/global/apiPayload/code/status/ErrorStatus.java
@@ -14,7 +14,10 @@ public enum ErrorStatus implements BaseCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러."),
     BAD_REQUEST(HttpStatus.BAD_REQUEST,"COMMON400","잘못된 요청입니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
-    FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다.");
+    FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+    
+    //공지
+    ANNOUNCEMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "ANNOUNCEMENT401", "요청하신 공지를 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
## 💜 Related Issue

> close #17 

## 💜 Work Details

> 셀러 공지 관련 API 구현
최상단 공지 1개 제한을 위해 seller 엔티티 구조 살짝 변경했습니다.

구현 API:
 - 공지 추가
 - 공지 삭제
 - 공지 리스트 조회
 - 최상단 공지/가장 최근 공지 조회
 - 공지 수정

## 💜 Review Requirement
