### PR TITLE
#34 Fix: itemStatus EXTEND 추가

### DIFF
--- a/src/main/java/com/influy/domain/item/controller/ItemRestController.java
+++ b/src/main/java/com/influy/domain/item/controller/ItemRestController.java
@@ -76,7 +76,7 @@ public class ItemRestController {
     }
 
     @PatchMapping("/{itemId}/status")
-    @Operation(summary = "개별 상품 표기 상태 설정")
+    @Operation(summary = "개별 상품 표기 상태 설정 | DEFAULT, EXTEND, SOLD_OUT")
     public ApiResponse<ItemResponseDto.ResultDto> setStatus(@PathVariable("sellerId") Long sellerId,
                                                             @PathVariable("itemId") Long itemId,
                                                             @RequestBody @Valid ItemRequestDto.StatusDto request) {

--- a/src/main/java/com/influy/domain/item/entity/ItemStatus.java
+++ b/src/main/java/com/influy/domain/item/entity/ItemStatus.java
@@ -1,5 +1,5 @@
 package com.influy.domain.item.entity;
 
 public enum ItemStatus {
-    DEFAULT, SOLD_OUT
+    DEFAULT, EXTEND, SOLD_OUT
 }


### PR DESCRIPTION
## 💜 Related Issue

> close #34

## 💜 Work Details

> item의 itemStatus Enum에 EXTEND 추가
> 아이템 마감일은 등록할때 설정되고 이후 마감일보다 일정을 미룰때만 연장하기 체크박스가 생성되므로 아이템이 미리 등록되어있지 않으면 EXTEND로 바꾸지 못하도록 설정 (ITEM NOT FOUND)

## 💜 Review Requirement

> 테스트 완료했슴니당 
> 우리 공용 db에서는 다시 create 해야할것 같아용 
