### PR TITLE
#51 Feature: 아이템 카테고리 조회 api 구현 / Fix: Like 예약어 오류 해결

### DIFF
--- a/src/main/java/com/influy/domain/category/controller/CategoryRestController.java
+++ b/src/main/java/com/influy/domain/category/controller/CategoryRestController.java
@@ -1,0 +1,31 @@
+package com.influy.domain.category.controller;
+
+import com.influy.domain.category.converter.CategoryConverter;
+import com.influy.domain.category.dto.CategoryResponseDto;
+import com.influy.domain.category.entity.Category;
+import com.influy.domain.category.repository.CategoryRepository;
+import com.influy.domain.category.service.CategoryService;
+import com.influy.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "아이템 카테고리", description = "아이템 카테고리 조회 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/categories")
+public class CategoryRestController {
+    private final CategoryService categoryService;
+
+    @GetMapping()
+    @Operation(summary = "아이템 카테고리 리스트 조회")
+    public ApiResponse<CategoryResponseDto.CategoryListDto> getCategories() {
+        List<Category> categoryList = categoryService.getCategories();
+        return ApiResponse.onSuccess(CategoryConverter.toItemCategoryListDto(categoryList));
+    }
+}

--- a/src/main/java/com/influy/domain/category/converter/CategoryConverter.java
+++ b/src/main/java/com/influy/domain/category/converter/CategoryConverter.java
@@ -1,0 +1,25 @@
+package com.influy.domain.category.converter;
+
+import com.influy.domain.category.dto.CategoryResponseDto;
+import com.influy.domain.category.entity.Category;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CategoryConverter {
+    public static CategoryResponseDto.CategoryDto toCategoryDto(Category category) {
+        return CategoryResponseDto.CategoryDto.builder()
+                .id(category.getId())
+                .name(category.getCategory())
+                .build();
+    }
+
+    public static CategoryResponseDto.CategoryListDto toItemCategoryListDto(List<Category> categoryList) {
+        List<CategoryResponseDto.CategoryDto> categoryDtoList = categoryList.stream()
+                .map(CategoryConverter::toCategoryDto).toList();
+
+        return CategoryResponseDto.CategoryListDto.builder()
+                .categoryDtoList(categoryDtoList)
+                .build();
+    }
+}

--- a/src/main/java/com/influy/domain/category/dto/CategoryResponseDto.java
+++ b/src/main/java/com/influy/domain/category/dto/CategoryResponseDto.java
@@ -1,0 +1,32 @@
+package com.influy.domain.category.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class CategoryResponseDto {
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CategoryDto {
+        @Schema(description = "카테고리 id", example = "1")
+        private Long id;
+
+        @Schema(description = "카테고리 이름", example = "사이즈")
+        private String name;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CategoryListDto {
+        @Schema(description = "카테고리 리스트")
+        private List<CategoryDto> categoryDtoList;
+    }
+}

--- a/src/main/java/com/influy/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/influy/domain/category/repository/CategoryRepository.java
@@ -6,5 +6,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
-    Optional<Category> findByCategory(String category);
 }

--- a/src/main/java/com/influy/domain/category/service/CategoryService.java
+++ b/src/main/java/com/influy/domain/category/service/CategoryService.java
@@ -1,0 +1,9 @@
+package com.influy.domain.category.service;
+
+import com.influy.domain.category.entity.Category;
+
+import java.util.List;
+
+public interface CategoryService {
+    List<Category> getCategories();
+}

--- a/src/main/java/com/influy/domain/category/service/CategoryServiceImpl.java
+++ b/src/main/java/com/influy/domain/category/service/CategoryServiceImpl.java
@@ -1,0 +1,21 @@
+package com.influy.domain.category.service;
+
+import com.influy.domain.category.entity.Category;
+import com.influy.domain.category.repository.CategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryServiceImpl implements CategoryService {
+    private final CategoryRepository categoryRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<Category> getCategories() {
+        return categoryRepository.findAll();
+    }
+}

--- a/src/main/java/com/influy/domain/faqCard/converter/FaqCardConverter.java
+++ b/src/main/java/com/influy/domain/faqCard/converter/FaqCardConverter.java
@@ -59,7 +59,7 @@ public class FaqCardConverter {
                 .pinned(faqCard.getIsPinned())
                 .adjustImg(faqCard.getAdjustImg())
                 .answerContent(nonNull(faqCard.getAnswerContent()))
-                .faqCategory(faqCard.getFaqCategory().getCategory())
+                .faqCategoryId(faqCard.getFaqCategory().getId())
                 .updatedAt(faqCard.getUpdatedAt())
                 .backgroundImgLink(nonNull(faqCard.getBackgroundImageLink()))
                 .build();
@@ -85,6 +85,8 @@ public class FaqCardConverter {
                 .questionContent(faqCard.getQuestionContent())
                 .answerContent(nonNull(faqCard.getAnswerContent()))
                 .backgroundImgLink(nonNull(faqCard.getBackgroundImageLink()))
+                .pinned(faqCard.getIsPinned())
+                .faqCategoryId(faqCard.getFaqCategory().getId())
                 .build();
     }
 

--- a/src/main/java/com/influy/domain/faqCard/dto/FaqCardRequestDto.java
+++ b/src/main/java/com/influy/domain/faqCard/dto/FaqCardRequestDto.java
@@ -41,5 +41,11 @@ public class FaqCardRequestDto {
 
         @Schema(description = "배경 이미지 링크", example = "xxxxx.png")
         private String backgroundImgLink;
+
+        @Schema(description = "고정하기 여부", example = "true")
+        private Boolean pinned;
+
+        @Schema(description = "FAQ 카테고리 id", example = "1")
+        private Long faqCategoryId;
     }
 }

--- a/src/main/java/com/influy/domain/faqCard/dto/FaqCardResponseDto.java
+++ b/src/main/java/com/influy/domain/faqCard/dto/FaqCardResponseDto.java
@@ -93,8 +93,8 @@ public class FaqCardResponseDto {
         @Schema(description = "배경 이미지 링크", example = "xxxxx.png")
         private String backgroundImgLink;
 
-        @Schema(description = "FAQ 카테고리", example = "색상")
-        private String faqCategory;
+        @Schema(description = "FAQ 카테고리 id", example = "1")
+        private Long faqCategoryId;
 
         @Schema(description = "업뎃일", example = "2021-01-01T00:00")
         private LocalDateTime updatedAt;
@@ -116,6 +116,12 @@ public class FaqCardResponseDto {
 
         @Schema(description = "배경 이미지 링크", example = "xxxxx.png")
         private String backgroundImgLink;
+
+        @Schema(description = "고정 여부", example = "true")
+        private boolean pinned;
+
+        @Schema(description = "FAQ 카테고리 id", example = "1")
+        private Long faqCategoryId;
     }
 
     @Getter

--- a/src/main/java/com/influy/domain/item/dto/ItemRequestDto.java
+++ b/src/main/java/com/influy/domain/item/dto/ItemRequestDto.java
@@ -25,9 +25,9 @@ public class ItemRequestDto {
         @Schema(description = "아이템 제목", example = "제작 원피스")
         private String name;
 
-        @Schema(description = "아이템 카테고리, 1~3개", example = "[\"뷰티\", \"패션\"]")
+        @Schema(description = "아이템 카테고리, 1~3개", example = "[\"1\", \"2\"]")
         @Size(max = 3, message = "카테고리는 최대 3개까지만 업로드할 수 있습니다.")
-        private List<String> itemCategoryList;
+        private List<Long> itemCategoryIdList;
 
         @Schema(description = "시작일", example = "021-01-01T00:00")
         private LocalDateTime startDate;

--- a/src/main/java/com/influy/domain/item/service/ItemServiceImpl.java
+++ b/src/main/java/com/influy/domain/item/service/ItemServiceImpl.java
@@ -100,7 +100,7 @@ public class ItemServiceImpl implements ItemService {
             createImageList(request, item);
         }
 
-        if (request.getItemCategoryList() != null) {
+        if (request.getItemCategoryIdList() != null) {
             item.getItemCategoryList().clear();
             createItemCategoryList(request, item);
         }
@@ -193,9 +193,9 @@ public class ItemServiceImpl implements ItemService {
     }
 
     private void createItemCategoryList(ItemRequestDto.DetailDto request, Item item) {
-        List<String> itemCategoryStrList = request.getItemCategoryList();
-        for (String str : itemCategoryStrList) {
-            Category category = categoryRepository.findByCategory(str)
+        List<Long> itemCategoryLongList = request.getItemCategoryIdList();
+        for (Long lg : itemCategoryLongList) {
+            Category category = categoryRepository.findById(lg)
                     .orElseThrow(() -> new GeneralException(ErrorStatus.ITEM_CATEGORY_NOT_FOUND));
             ItemCategory itemCategory = ItemCategoryConverter.toItemCategory(category, item);
             category.getItemCategoryList().add(itemCategory);

--- a/src/main/java/com/influy/domain/like/entity/Like.java
+++ b/src/main/java/com/influy/domain/like/entity/Like.java
@@ -12,6 +12,7 @@ import lombok.*;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Table(name = "likes")
 public class Like {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/influy/domain/member/entity/Member.java
+++ b/src/main/java/com/influy/domain/member/entity/Member.java
@@ -42,6 +42,7 @@ public class Member extends BaseEntity {
     private MemberRole role;
 
     @Nullable
+    @Setter
     @OneToOne(mappedBy = "member")
     private SellerProfile sellerProfile;
 

--- a/src/main/java/com/influy/domain/sellerProfile/service/SellerProfileServiceImpl.java
+++ b/src/main/java/com/influy/domain/sellerProfile/service/SellerProfileServiceImpl.java
@@ -54,7 +54,7 @@ public class SellerProfileServiceImpl implements SellerProfileService {
     public SellerProfile createSellerProfile(Member member, MemberRequestDTO.SellerJoin request) {
 
         SellerProfile sellerProfile = SellerProfileConverter.toSellerProfile(member,request);
-
+        member.setSellerProfile(sellerProfile);
         return sellerProfileRepository.save(sellerProfile);
     }
 }

--- a/src/main/resources/category-storage/category.json
+++ b/src/main/resources/category-storage/category.json
@@ -27,13 +27,13 @@
     "category": "스포츠/레저"
   },
   {
-    "category": "선물"
+    "category": "여행"
   },
   {
     "category": "명품"
   },
   {
-    "category": "여행"
+    "category": "선물"
   },
   {
     "category": "기념일"


### PR DESCRIPTION
## 💜 Related Issue

> #51

## 💜 Work Details

> 아이템 카테고리 조회 api 구현
> 아이템 카테고리 순서 수정 (선물 <-> 여행)
> Like 예약어 오류 해결
> faq 카테고리 id로 조회하도록 수정

## 💜 Review Requirement

> ec2에서 로그를 봤을때 like 테이블 이름 때문에 에러가 나는 것 같아서 수정해봤어요 지금 찜 개발하고 있는거에서는 이미 수정해서 개발하고 있었는데 저번 커밋에서는 따로 처리를 안했었나봅니당..
> 테스트 완료했슴당
> 머지 전 디비 드랍했다가 다시!
