### PR TITLE
#51 Fix: FAQ 카테고리 순서 관련 CRUD 수정

### DIFF
--- a/src/main/java/com/influy/domain/faqCard/repository/FaqCardRepository.java
+++ b/src/main/java/com/influy/domain/faqCard/repository/FaqCardRepository.java
@@ -1,10 +1,12 @@
 package com.influy.domain.faqCard.repository;
 
 import com.influy.domain.faqCard.entity.FaqCard;
+import com.influy.domain.faqCategory.entity.FaqCategory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FaqCardRepository extends JpaRepository<FaqCard, Long> {
     Page<FaqCard> findByFaqCategoryId(Long faqCategoryId, Pageable pageable);
+    void deleteAllByFaqCategory(FaqCategory faqCategory);
 }

--- a/src/main/java/com/influy/domain/faqCategory/controller/FaqRestController.java
+++ b/src/main/java/com/influy/domain/faqCategory/controller/FaqRestController.java
@@ -35,7 +35,7 @@ public class FaqRestController {
     }
 
     @GetMapping("/{sellerId}/items/{itemId}/faq-categories")
-    @Operation(summary = "개별 상품의 faq 카테고리 리스트 조회 (등록순 정렬)")
+    @Operation(summary = "개별 상품의 faq 카테고리 리스트 조회 (순서 기준 정렬)")
     public ApiResponse<FaqCategoryResponseDto.PageDto> getPage (@PathVariable("sellerId") Long sellerId,
                                                                 @PathVariable("itemId") Long itemId,
                                                                 @Valid @ParameterObject PageRequestDto pageRequest) {

--- a/src/main/java/com/influy/domain/faqCategory/controller/FaqRestController.java
+++ b/src/main/java/com/influy/domain/faqCategory/controller/FaqRestController.java
@@ -26,11 +26,11 @@ public class FaqRestController {
 
     @PostMapping("/items/{itemId}/faq-categories")
     @Operation(summary = "개별 상품의 faq 카테고리 추가 (한번에 하나)")
-    public ApiResponse<FaqCategoryResponseDto.AddResultDto> addAll (@RequestParam(value="sellerId",defaultValue = "1") Long sellerId,
+    public ApiResponse<FaqCategoryResponseDto.ViewDto> add(@RequestParam(value="sellerId",defaultValue = "1") Long sellerId,
                                                                     @PathVariable("itemId") Long itemId,
-                                                                    @RequestBody List<FaqCategoryRequestDto.AddDto> requestList) {
-        List<FaqCategory> faqCategoryList = faqCategoryService.addAll(sellerId, itemId, requestList);
-        return ApiResponse.onSuccess(FaqCategoryConverter.toAddResultDto(faqCategoryList));
+                                                                    @RequestBody FaqCategoryRequestDto.AddDto request) {
+        FaqCategory faqCategory = faqCategoryService.add(sellerId, itemId, request);
+        return ApiResponse.onSuccess(FaqCategoryConverter.toViewDto(faqCategory));
     }
 
     @GetMapping("/{sellerId}/items/{itemId}/faq-categories")
@@ -44,29 +44,29 @@ public class FaqRestController {
 
     @DeleteMapping("/items/{itemId}/faq-categories")
     @Operation(summary = "개별 상품의 faq 카테고리 삭제 (한번에 하나)")
-    public ApiResponse<FaqCategoryResponseDto.DeleteResultDto> deleteAll (@RequestParam(value="sellerId",defaultValue = "1") Long sellerId,
+    public ApiResponse<FaqCategoryResponseDto.DeleteResultDto> delete(@RequestParam(value="sellerId",defaultValue = "1") Long sellerId,
                                                                           @PathVariable("itemId") Long itemId,
-                                                                          @RequestBody @Valid List<FaqCategoryRequestDto.DeleteDto> requestList) {
-        faqCategoryService.deleteAll(sellerId, itemId, requestList);
-        return ApiResponse.onSuccess(FaqCategoryConverter.toDeleteResultDto(requestList));
+                                                                          @RequestBody @Valid FaqCategoryRequestDto.DeleteDto request) {
+        faqCategoryService.delete(sellerId, itemId, request);
+        return ApiResponse.onSuccess(FaqCategoryConverter.toDeleteResultDto(request));
     }
 
     @PatchMapping("/items/{itemId}/faq-categories")
-    @Operation(summary = "개별 상품의 faq 카테고리 이름 수정 (한번에 여러개 가능)")
-    public ApiResponse<FaqCategoryResponseDto.UpdateResultDto> update(@RequestParam(value="sellerId",defaultValue = "1") Long sellerId,
+    @Operation(summary = "개별 상품의 faq 카테고리 이름 수정 (한번에 하나)")
+    public ApiResponse<FaqCategoryResponseDto.ViewDto> update(@RequestParam(value="sellerId",defaultValue = "1") Long sellerId,
                                                                               @PathVariable("itemId") Long itemId,
-                                                                              @RequestBody @Valid List<FaqCategoryRequestDto.UpdateOrderDto> requestList) {
-        List<FaqCategory> faqCategoryList = faqCategoryService.updateOrderAll(sellerId, itemId, requestList);
-        return ApiResponse.onSuccess(FaqCategoryConverter.toUpdateResultDto(faqCategoryList));
+                                                                              @RequestBody @Valid FaqCategoryRequestDto.UpdateDto request) {
+        FaqCategory faqCategory = faqCategoryService.update(sellerId, itemId, request);
+        return ApiResponse.onSuccess(FaqCategoryConverter.toViewDto(faqCategory));
     }
 
-    @PatchMapping("/items/{itemId}/faq-categories")
+    @PatchMapping("/items/{itemId}/faq-categories/order")
     @Operation(summary = "개별 상품의 faq 카테고리 순서 수정 (한번에 여러개 가능)")
-    public ApiResponse<FaqCategoryResponseDto.UpdateResultDto> updateOrderAll(@RequestParam(value="sellerId",defaultValue = "1") Long sellerId,
+    public ApiResponse<FaqCategoryResponseDto.UpdateOrderResultDto> updateOrderAll(@RequestParam(value="sellerId",defaultValue = "1") Long sellerId,
                                                                    @PathVariable("itemId") Long itemId,
                                                                    @RequestBody @Valid List<FaqCategoryRequestDto.UpdateOrderDto> requestList) {
         List<FaqCategory> faqCategoryList = faqCategoryService.updateOrderAll(sellerId, itemId, requestList);
-        return ApiResponse.onSuccess(FaqCategoryConverter.toUpdateResultDto(faqCategoryList));
+        return ApiResponse.onSuccess(FaqCategoryConverter.toUpdateOrderResultDto(faqCategoryList));
     }
 }
 

--- a/src/main/java/com/influy/domain/faqCategory/controller/FaqRestController.java
+++ b/src/main/java/com/influy/domain/faqCategory/controller/FaqRestController.java
@@ -7,7 +7,6 @@ import com.influy.domain.faqCategory.service.FaqCategoryService;
 import com.influy.domain.faqCategory.converter.FaqCategoryConverter;
 import com.influy.global.apiPayload.ApiResponse;
 import com.influy.global.common.PageRequestDto;
-import com.influy.global.validation.annotation.CheckPage;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -26,7 +25,7 @@ public class FaqRestController {
     private final FaqCategoryService faqCategoryService;
 
     @PostMapping("/items/{itemId}/faq-categories")
-    @Operation(summary = "개별 상품의 faq 카테고리 추가 (한번에 여러개 가능)")
+    @Operation(summary = "개별 상품의 faq 카테고리 추가 (한번에 하나)")
     public ApiResponse<FaqCategoryResponseDto.AddResultDto> addAll (@RequestParam(value="sellerId",defaultValue = "1") Long sellerId,
                                                                     @PathVariable("itemId") Long itemId,
                                                                     @RequestBody List<FaqCategoryRequestDto.AddDto> requestList) {
@@ -44,7 +43,7 @@ public class FaqRestController {
     }
 
     @DeleteMapping("/items/{itemId}/faq-categories")
-    @Operation(summary = "개별 상품의 faq 카테고리 삭제")
+    @Operation(summary = "개별 상품의 faq 카테고리 삭제 (한번에 하나)")
     public ApiResponse<FaqCategoryResponseDto.DeleteResultDto> deleteAll (@RequestParam(value="sellerId",defaultValue = "1") Long sellerId,
                                                                           @PathVariable("itemId") Long itemId,
                                                                           @RequestBody @Valid List<FaqCategoryRequestDto.DeleteDto> requestList) {
@@ -53,11 +52,21 @@ public class FaqRestController {
     }
 
     @PatchMapping("/items/{itemId}/faq-categories")
-    @Operation(summary = "개별 상품의 faq 카테고리 수정")
-    public ApiResponse<FaqCategoryResponseDto.UpdateResultDto> updateAll(@RequestParam(value="sellerId",defaultValue = "1") Long sellerId,
+    @Operation(summary = "개별 상품의 faq 카테고리 이름 수정 (한번에 여러개 가능)")
+    public ApiResponse<FaqCategoryResponseDto.UpdateResultDto> update(@RequestParam(value="sellerId",defaultValue = "1") Long sellerId,
+                                                                              @PathVariable("itemId") Long itemId,
+                                                                              @RequestBody @Valid List<FaqCategoryRequestDto.UpdateOrderDto> requestList) {
+        List<FaqCategory> faqCategoryList = faqCategoryService.updateOrderAll(sellerId, itemId, requestList);
+        return ApiResponse.onSuccess(FaqCategoryConverter.toUpdateResultDto(faqCategoryList));
+    }
+
+    @PatchMapping("/items/{itemId}/faq-categories")
+    @Operation(summary = "개별 상품의 faq 카테고리 순서 수정 (한번에 여러개 가능)")
+    public ApiResponse<FaqCategoryResponseDto.UpdateResultDto> updateOrderAll(@RequestParam(value="sellerId",defaultValue = "1") Long sellerId,
                                                                    @PathVariable("itemId") Long itemId,
-                                                                   @RequestBody @Valid List<FaqCategoryRequestDto.UpdateDto> requestList) {
-        List<FaqCategory> faqCategoryList = faqCategoryService.updateAll(sellerId, itemId, requestList);
+                                                                   @RequestBody @Valid List<FaqCategoryRequestDto.UpdateOrderDto> requestList) {
+        List<FaqCategory> faqCategoryList = faqCategoryService.updateOrderAll(sellerId, itemId, requestList);
         return ApiResponse.onSuccess(FaqCategoryConverter.toUpdateResultDto(faqCategoryList));
     }
 }
+

--- a/src/main/java/com/influy/domain/faqCategory/controller/FaqRestController.java
+++ b/src/main/java/com/influy/domain/faqCategory/controller/FaqRestController.java
@@ -64,8 +64,8 @@ public class FaqRestController {
     @Operation(summary = "개별 상품의 faq 카테고리 순서 수정 (한번에 여러개 가능)")
     public ApiResponse<FaqCategoryResponseDto.UpdateOrderResultDto> updateOrderAll(@RequestParam(value="sellerId",defaultValue = "1") Long sellerId,
                                                                    @PathVariable("itemId") Long itemId,
-                                                                   @RequestBody @Valid List<FaqCategoryRequestDto.UpdateOrderDto> requestList) {
-        List<FaqCategory> faqCategoryList = faqCategoryService.updateOrderAll(sellerId, itemId, requestList);
+                                                                   @RequestBody @Valid FaqCategoryRequestDto.UpdateOrderDto request) {
+        List<FaqCategory> faqCategoryList = faqCategoryService.updateOrderAll(sellerId, itemId, request);
         return ApiResponse.onSuccess(FaqCategoryConverter.toUpdateOrderResultDto(faqCategoryList));
     }
 }

--- a/src/main/java/com/influy/domain/faqCategory/converter/FaqCategoryConverter.java
+++ b/src/main/java/com/influy/domain/faqCategory/converter/FaqCategoryConverter.java
@@ -23,6 +23,7 @@ public class FaqCategoryConverter {
         return FaqCategoryResponseDto.ViewDto.builder()
                 .id(faqCategory.getId())
                 .category(faqCategory.getCategory())
+                .categoryOrder(faqCategory.getCategoryOrder())
                 .build();
     }
 
@@ -51,10 +52,11 @@ public class FaqCategoryConverter {
                 .build();
     }
 
-    public static FaqCategory toFaqCategory(FaqCategoryRequestDto.AddDto request, Item item) {
+    public static FaqCategory toFaqCategory(FaqCategoryRequestDto.AddDto request, Item item, Integer nextNum) {
         return FaqCategory.builder()
                 .item(item)
                 .category(request.getCategory())
+                .categoryOrder(nextNum)
                 .build();
     }
 
@@ -63,6 +65,7 @@ public class FaqCategoryConverter {
                 .map(f -> FaqCategoryResponseDto.ViewDto.builder()
                         .id(f.getId())
                         .category(f.getCategory())
+                        .categoryOrder(f.getCategoryOrder())
                         .build())
                 .toList();
 

--- a/src/main/java/com/influy/domain/faqCategory/converter/FaqCategoryConverter.java
+++ b/src/main/java/com/influy/domain/faqCategory/converter/FaqCategoryConverter.java
@@ -10,15 +10,6 @@ import java.util.List;
 
 public class FaqCategoryConverter {
 
-    public static FaqCategoryResponseDto.AddResultDto toAddResultDto(List<FaqCategory> faqCategoryList) {
-        List<FaqCategoryResponseDto.ViewDto> addList = faqCategoryList.stream()
-                .map(FaqCategoryConverter::toViewDto).toList();
-
-        return FaqCategoryResponseDto.AddResultDto.builder()
-                .addList(addList)
-                .build();
-    }
-
     public static FaqCategoryResponseDto.ViewDto toViewDto(FaqCategory faqCategory) {
         return FaqCategoryResponseDto.ViewDto.builder()
                 .id(faqCategory.getId())
@@ -42,13 +33,9 @@ public class FaqCategoryConverter {
                 .build();
     }
 
-    public static FaqCategoryResponseDto.DeleteResultDto toDeleteResultDto(List<FaqCategoryRequestDto.DeleteDto> faqCategoryIdList) {
-        List<Long> idList = faqCategoryIdList.stream()
-                .map(FaqCategoryRequestDto.DeleteDto::getId)
-                .toList();
-
+    public static FaqCategoryResponseDto.DeleteResultDto toDeleteResultDto(FaqCategoryRequestDto.DeleteDto request) {
         return FaqCategoryResponseDto.DeleteResultDto.builder()
-                .idList(idList)
+                .id(request.getId())
                 .build();
     }
 
@@ -60,7 +47,7 @@ public class FaqCategoryConverter {
                 .build();
     }
 
-    public static FaqCategoryResponseDto.UpdateResultDto toUpdateResultDto(List<FaqCategory> faqCategoryList) {
+    public static FaqCategoryResponseDto.UpdateOrderResultDto toUpdateOrderResultDto(List<FaqCategory> faqCategoryList) {
         List<FaqCategoryResponseDto.ViewDto> updatedList = faqCategoryList.stream()
                 .map(f -> FaqCategoryResponseDto.ViewDto.builder()
                         .id(f.getId())
@@ -69,7 +56,7 @@ public class FaqCategoryConverter {
                         .build())
                 .toList();
 
-        return FaqCategoryResponseDto.UpdateResultDto.builder()
+        return FaqCategoryResponseDto.UpdateOrderResultDto.builder()
                 .updatedList(updatedList)
                 .build();
     }

--- a/src/main/java/com/influy/domain/faqCategory/dto/FaqCategoryRequestDto.java
+++ b/src/main/java/com/influy/domain/faqCategory/dto/FaqCategoryRequestDto.java
@@ -35,5 +35,8 @@ public class FaqCategoryRequestDto {
 
         @Schema(description = "faq 카테고리", example = "진행일정")
         private String category;
+
+        @Schema(description = "faq 카테고리 순서", example = "1")
+        private Integer categoryOrder;
     }
 }

--- a/src/main/java/com/influy/domain/faqCategory/dto/FaqCategoryRequestDto.java
+++ b/src/main/java/com/influy/domain/faqCategory/dto/FaqCategoryRequestDto.java
@@ -29,6 +29,18 @@ public class FaqCategoryRequestDto {
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
+    public static class UpdateDto {
+        @Schema(description = "faq 카테고리 id", example = "1")
+        private Long id;
+
+        @Schema(description = "faq 카테고리", example = "진행일정")
+        private String category;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
     public static class UpdateOrderDto {
         @Schema(description = "faq 카테고리 id", example = "1")
         private Long id;

--- a/src/main/java/com/influy/domain/faqCategory/dto/FaqCategoryRequestDto.java
+++ b/src/main/java/com/influy/domain/faqCategory/dto/FaqCategoryRequestDto.java
@@ -29,12 +29,9 @@ public class FaqCategoryRequestDto {
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class UpdateDto {
+    public static class UpdateOrderDto {
         @Schema(description = "faq 카테고리 id", example = "1")
         private Long id;
-
-        @Schema(description = "faq 카테고리", example = "진행일정")
-        private String category;
 
         @Schema(description = "faq 카테고리 순서", example = "1")
         private Integer categoryOrder;

--- a/src/main/java/com/influy/domain/faqCategory/dto/FaqCategoryRequestDto.java
+++ b/src/main/java/com/influy/domain/faqCategory/dto/FaqCategoryRequestDto.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 public class FaqCategoryRequestDto {
     @Getter
     @Builder
@@ -42,10 +44,7 @@ public class FaqCategoryRequestDto {
     @AllArgsConstructor
     @NoArgsConstructor
     public static class UpdateOrderDto {
-        @Schema(description = "faq 카테고리 id", example = "1")
-        private Long id;
-
-        @Schema(description = "faq 카테고리 순서", example = "1")
-        private Integer categoryOrder;
+        @Schema(description = "faq 카테고리 id", example = "[5, 3, 2, 0, 1, 4]")
+        private List<Long> ids;
     }
 }

--- a/src/main/java/com/influy/domain/faqCategory/dto/FaqCategoryResponseDto.java
+++ b/src/main/java/com/influy/domain/faqCategory/dto/FaqCategoryResponseDto.java
@@ -28,6 +28,9 @@ public class FaqCategoryResponseDto {
 
         @Schema(description = "faq 카테고리", example = "상품구성")
         private String category;
+
+        @Schema(description = "faq 카테고리 순서", example = "1")
+        private Integer categoryOrder;
     }
 
     @Getter

--- a/src/main/java/com/influy/domain/faqCategory/dto/FaqCategoryResponseDto.java
+++ b/src/main/java/com/influy/domain/faqCategory/dto/FaqCategoryResponseDto.java
@@ -62,7 +62,7 @@ public class FaqCategoryResponseDto {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class UpdateResultDto {
-        @Schema(description = "업데이트된 faq 카테고리 리스트", example = "[1, 2]")
+        @Schema(description = "업데이트된 faq 카테고리 리스트")
         private List<ViewDto> updatedList;
     }
 }

--- a/src/main/java/com/influy/domain/faqCategory/dto/FaqCategoryResponseDto.java
+++ b/src/main/java/com/influy/domain/faqCategory/dto/FaqCategoryResponseDto.java
@@ -13,15 +13,6 @@ public class FaqCategoryResponseDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class AddResultDto {
-        @Schema(description = "추가된 faq 카테고리 리스트")
-        private List<ViewDto> addList;
-    }
-
-    @Getter
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
     public static class ViewDto {
         @Schema(description = "faq 카테고리 id", example = "1")
         private Long id;
@@ -53,15 +44,15 @@ public class FaqCategoryResponseDto {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class DeleteResultDto {
-        @Schema(description = "삭제된 faq 카테고리 id 리스트", example = "[1, 2]")
-        private List<Long> idList;
+        @Schema(description = "삭제된 faq 카테고리 id", example = "1")
+        private Long id;
     }
 
     @Getter
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class UpdateResultDto {
+    public static class UpdateOrderResultDto {
         @Schema(description = "업데이트된 faq 카테고리 리스트")
         private List<ViewDto> updatedList;
     }

--- a/src/main/java/com/influy/domain/faqCategory/entity/FaqCategory.java
+++ b/src/main/java/com/influy/domain/faqCategory/entity/FaqCategory.java
@@ -26,6 +26,8 @@ public class FaqCategory extends BaseEntity {
 
     private String category;
 
+    private Integer categoryOrder;
+
     @OneToMany(mappedBy = "faqCategory", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<FaqCard> faqCardList = new ArrayList<>();

--- a/src/main/java/com/influy/domain/faqCategory/entity/FaqCategory.java
+++ b/src/main/java/com/influy/domain/faqCategory/entity/FaqCategory.java
@@ -12,7 +12,6 @@ import java.util.List;
 @Entity
 @Builder
 @Getter
-@Setter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FaqCategory extends BaseEntity {
@@ -24,8 +23,10 @@ public class FaqCategory extends BaseEntity {
     @JoinColumn(name = "item_id")
     private Item item;
 
+    @Setter
     private String category;
 
+    @Setter
     private Integer categoryOrder;
 
     @OneToMany(mappedBy = "faqCategory", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/com/influy/domain/faqCategory/repository/FaqCategoryRepository.java
+++ b/src/main/java/com/influy/domain/faqCategory/repository/FaqCategoryRepository.java
@@ -3,10 +3,9 @@ package com.influy.domain.faqCategory.repository;
 import com.influy.domain.faqCategory.entity.FaqCategory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -15,10 +14,5 @@ public interface FaqCategoryRepository extends JpaRepository<FaqCategory, Long> 
     boolean existsByItemIdAndCategory(Long itemId, String category);
     @Query("SELECT MAX(f.categoryOrder) FROM FaqCategory f")
     Integer findMaxOrder();
-    @Modifying
-    @Query("UPDATE FaqCategory f SET f.categoryOrder = f.categoryOrder + 1 " +
-            "WHERE f.item.id = :itemId AND f.categoryOrder >= :startOrder AND f.categoryOrder < :endOrder")
-    void incrementOrdersFrom(@Param("itemId") Long itemId, @Param("startOrder") Integer startOrder, @Param("endOrder") Integer endOrder);
-    List<FaqCategory> findAllByItemId(Long itemId);
-    List<FaqCategory> findAllByItemIdAndCategoryOrderAsc(Long itemId);
+    List<FaqCategory> findAllByItemId(Long itemId, Sort sort);
 }

--- a/src/main/java/com/influy/domain/faqCategory/repository/FaqCategoryRepository.java
+++ b/src/main/java/com/influy/domain/faqCategory/repository/FaqCategoryRepository.java
@@ -1,18 +1,20 @@
 package com.influy.domain.faqCategory.repository;
 
 import com.influy.domain.faqCategory.entity.FaqCategory;
+import com.influy.domain.item.entity.Item;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.Collection;
 import java.util.List;
 
 public interface FaqCategoryRepository extends JpaRepository<FaqCategory, Long> {
     Page<FaqCategory> findAllByItemId(Long itemId, Pageable pageable);
     boolean existsByItemIdAndCategory(Long itemId, String category);
-    @Query("SELECT MAX(f.categoryOrder) FROM FaqCategory f")
-    Integer findMaxOrder();
     List<FaqCategory> findAllByItemId(Long itemId, Sort sort);
+    int countAllByItemId(Long itemId);
+    List<FaqCategory> findAllByItem(Item item);
 }

--- a/src/main/java/com/influy/domain/faqCategory/repository/FaqCategoryRepository.java
+++ b/src/main/java/com/influy/domain/faqCategory/repository/FaqCategoryRepository.java
@@ -20,4 +20,5 @@ public interface FaqCategoryRepository extends JpaRepository<FaqCategory, Long> 
             "WHERE f.item.id = :itemId AND f.categoryOrder >= :startOrder AND f.categoryOrder < :endOrder")
     void incrementOrdersFrom(@Param("itemId") Long itemId, @Param("startOrder") Integer startOrder, @Param("endOrder") Integer endOrder);
     List<FaqCategory> findAllByItemId(Long itemId);
+    List<FaqCategory> findAllByItemIdAndCategoryOrderAsc(Long itemId);
 }

--- a/src/main/java/com/influy/domain/faqCategory/repository/FaqCategoryRepository.java
+++ b/src/main/java/com/influy/domain/faqCategory/repository/FaqCategoryRepository.java
@@ -8,6 +8,8 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+
 public interface FaqCategoryRepository extends JpaRepository<FaqCategory, Long> {
     Page<FaqCategory> findAllByItemId(Long itemId, Pageable pageable);
     boolean existsByItemIdAndCategory(Long itemId, String category);
@@ -17,4 +19,5 @@ public interface FaqCategoryRepository extends JpaRepository<FaqCategory, Long> 
     @Query("UPDATE FaqCategory f SET f.categoryOrder = f.categoryOrder + 1 " +
             "WHERE f.item.id = :itemId AND f.categoryOrder >= :startOrder AND f.categoryOrder < :endOrder")
     void incrementOrdersFrom(@Param("itemId") Long itemId, @Param("startOrder") Integer startOrder, @Param("endOrder") Integer endOrder);
+    List<FaqCategory> findAllByItemId(Long itemId);
 }

--- a/src/main/java/com/influy/domain/faqCategory/repository/FaqCategoryRepository.java
+++ b/src/main/java/com/influy/domain/faqCategory/repository/FaqCategoryRepository.java
@@ -4,11 +4,17 @@ import com.influy.domain.faqCategory.entity.FaqCategory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface FaqCategoryRepository extends JpaRepository<FaqCategory, Long> {
     Page<FaqCategory> findAllByItemId(Long itemId, Pageable pageable);
     boolean existsByItemIdAndCategory(Long itemId, String category);
     @Query("SELECT MAX(f.categoryOrder) FROM FaqCategory f")
     Integer findMaxOrder();
+    @Modifying
+    @Query("UPDATE FaqCategory f SET f.categoryOrder = f.categoryOrder + 1 " +
+            "WHERE f.item.id = :itemId AND f.categoryOrder >= :startOrder AND f.categoryOrder < :endOrder")
+    void incrementOrdersFrom(@Param("itemId") Long itemId, @Param("startOrder") Integer startOrder, @Param("endOrder") Integer endOrder);
 }

--- a/src/main/java/com/influy/domain/faqCategory/repository/FaqCategoryRepository.java
+++ b/src/main/java/com/influy/domain/faqCategory/repository/FaqCategoryRepository.java
@@ -4,8 +4,11 @@ import com.influy.domain.faqCategory.entity.FaqCategory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface FaqCategoryRepository extends JpaRepository<FaqCategory, Long> {
     Page<FaqCategory> findAllByItemId(Long itemId, Pageable pageable);
     boolean existsByItemIdAndCategory(Long itemId, String category);
+    @Query("SELECT MAX(f.categoryOrder) FROM FaqCategory f")
+    Integer findMaxOrder();
 }

--- a/src/main/java/com/influy/domain/faqCategory/service/FaqCategoryService.java
+++ b/src/main/java/com/influy/domain/faqCategory/service/FaqCategoryService.java
@@ -11,5 +11,5 @@ public interface FaqCategoryService {
     List<FaqCategory> addAll(Long sellerId, Long itemId, List<FaqCategoryRequestDto.AddDto> requestList);
     Page<FaqCategory> getPage(Long sellerId, Long itemId, PageRequestDto pageRequest);
     void deleteAll(Long sellerId, Long itemId, List<FaqCategoryRequestDto.DeleteDto> requestList);
-    List<FaqCategory> updateAll(Long sellerId, Long itemId, List<FaqCategoryRequestDto.UpdateDto> requestList);
+    List<FaqCategory> updateOrderAll(Long sellerId, Long itemId, List<FaqCategoryRequestDto.UpdateOrderDto> requestList);
 }

--- a/src/main/java/com/influy/domain/faqCategory/service/FaqCategoryService.java
+++ b/src/main/java/com/influy/domain/faqCategory/service/FaqCategoryService.java
@@ -8,8 +8,9 @@ import org.springframework.data.domain.Page;
 import java.util.List;
 
 public interface FaqCategoryService {
-    List<FaqCategory> addAll(Long sellerId, Long itemId, List<FaqCategoryRequestDto.AddDto> requestList);
+    FaqCategory add(Long sellerId, Long itemId, FaqCategoryRequestDto.AddDto request);
     Page<FaqCategory> getPage(Long sellerId, Long itemId, PageRequestDto pageRequest);
-    void deleteAll(Long sellerId, Long itemId, List<FaqCategoryRequestDto.DeleteDto> requestList);
+    void delete(Long sellerId, Long itemId, FaqCategoryRequestDto.DeleteDto request);
+    FaqCategory update(Long sellerId, Long itemId, FaqCategoryRequestDto.UpdateDto request);
     List<FaqCategory> updateOrderAll(Long sellerId, Long itemId, List<FaqCategoryRequestDto.UpdateOrderDto> requestList);
 }

--- a/src/main/java/com/influy/domain/faqCategory/service/FaqCategoryService.java
+++ b/src/main/java/com/influy/domain/faqCategory/service/FaqCategoryService.java
@@ -12,5 +12,5 @@ public interface FaqCategoryService {
     Page<FaqCategory> getPage(Long sellerId, Long itemId, PageRequestDto pageRequest);
     void delete(Long sellerId, Long itemId, FaqCategoryRequestDto.DeleteDto request);
     FaqCategory update(Long sellerId, Long itemId, FaqCategoryRequestDto.UpdateDto request);
-    List<FaqCategory> updateOrderAll(Long sellerId, Long itemId, List<FaqCategoryRequestDto.UpdateOrderDto> requestList);
+    List<FaqCategory> updateOrderAll(Long sellerId, Long itemId, FaqCategoryRequestDto.UpdateOrderDto request);
 }

--- a/src/main/java/com/influy/domain/faqCategory/service/FaqCategoryServiceImpl.java
+++ b/src/main/java/com/influy/domain/faqCategory/service/FaqCategoryServiceImpl.java
@@ -38,12 +38,20 @@ public class FaqCategoryServiceImpl implements FaqCategoryService {
 
         List<FaqCategory> faqCategoryList = new ArrayList<>();
 
-        for (FaqCategoryRequestDto.AddDto request : requestList) {
+        int nextNum = 0;
+        if (faqCategoryRepository.count() != 0) nextNum = faqCategoryRepository.findMaxOrder();
+
+
+        for (int i=0; i<requestList.size(); i++) {
+            FaqCategoryRequestDto.AddDto requestDto = requestList.get(i);
+
             // 중복 체크
-            boolean exists = faqCategoryRepository.existsByItemIdAndCategory(itemId, request.getCategory());
+            boolean exists = faqCategoryRepository.existsByItemIdAndCategory(itemId, requestDto.getCategory());
             if (exists) throw new GeneralException(ErrorStatus.FAQ_CATEGORY_ALREADY_EXISTS);
 
-            FaqCategory newFaqCategory= FaqCategoryConverter.toFaqCategory(request, item);
+            // 순서: 들어온 순서대로 nextNum부터 증가
+            nextNum += 1;
+            FaqCategory newFaqCategory= FaqCategoryConverter.toFaqCategory(requestDto, item, nextNum);
             faqCategoryList.add(newFaqCategory);
             item.getFaqCategoryList().add(newFaqCategory);
         }

--- a/src/main/java/com/influy/domain/faqCategory/service/FaqCategoryServiceImpl.java
+++ b/src/main/java/com/influy/domain/faqCategory/service/FaqCategoryServiceImpl.java
@@ -100,8 +100,6 @@ public class FaqCategoryServiceImpl implements FaqCategoryService {
         if (!faqCategory.getItem().getId().equals(item.getId())) throw new GeneralException(ErrorStatus.INVALID_FAQ_ITEM_RELATION);
 
         if (request.getCategory() != null) faqCategory.setCategory(request.getCategory());
-        faqCategoryRepository.save(faqCategory);
-
         return faqCategory;
     }
 
@@ -130,7 +128,6 @@ public class FaqCategoryServiceImpl implements FaqCategoryService {
             }
             faqCategory.setCategoryOrder(i + 1);
             updatedList.add(faqCategory);
-            faqCategoryRepository.save(faqCategory);
         }
 
         return updatedList;

--- a/src/main/java/com/influy/domain/faqCategory/service/FaqCategoryServiceImpl.java
+++ b/src/main/java/com/influy/domain/faqCategory/service/FaqCategoryServiceImpl.java
@@ -1,5 +1,6 @@
 package com.influy.domain.faqCategory.service;
 
+import com.influy.domain.faqCard.repository.FaqCardRepository;
 import com.influy.domain.faqCategory.converter.FaqCategoryConverter;
 import com.influy.domain.faqCategory.dto.FaqCategoryRequestDto;
 import com.influy.domain.faqCategory.entity.FaqCategory;
@@ -26,36 +27,29 @@ public class FaqCategoryServiceImpl implements FaqCategoryService {
     private final SellerProfileRepository sellerRepository;
     private final ItemRepository itemRepository;
     private final FaqCategoryRepository faqCategoryRepository;
+    private final FaqCardRepository faqCardRepository;
 
 
     @Override
     @Transactional
-    public List<FaqCategory> addAll(Long sellerId, Long itemId, List<FaqCategoryRequestDto.AddDto> requestList) {
+    public FaqCategory add(Long sellerId, Long itemId, FaqCategoryRequestDto.AddDto request) {
         if (!sellerRepository.existsById(sellerId)) throw new GeneralException(ErrorStatus.SELLER_NOT_FOUND);
         Item item = itemRepository.findById(itemId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.ITEM_NOT_FOUND));
 
-        List<FaqCategory> faqCategoryList = new ArrayList<>();
-
         int nextNum = 0;
         if (faqCategoryRepository.count() != 0) nextNum = faqCategoryRepository.findMaxOrder();
 
+        // 중복 체크
+        boolean exists = faqCategoryRepository.existsByItemIdAndCategory(itemId, request.getCategory());
+        if (exists) throw new GeneralException(ErrorStatus.FAQ_CATEGORY_ALREADY_EXISTS);
 
-        for (int i=0; i<requestList.size(); i++) {
-            FaqCategoryRequestDto.AddDto requestDto = requestList.get(i);
+        // 순서: nextNum +1 부터 시작
+        nextNum += 1;
+        FaqCategory newFaqCategory= FaqCategoryConverter.toFaqCategory(request, item, nextNum);
+        item.getFaqCategoryList().add(newFaqCategory);
 
-            // 중복 체크
-            boolean exists = faqCategoryRepository.existsByItemIdAndCategory(itemId, requestDto.getCategory());
-            if (exists) throw new GeneralException(ErrorStatus.FAQ_CATEGORY_ALREADY_EXISTS);
-
-            // 순서: 들어온 순서대로 nextNum부터 증가
-            nextNum += 1;
-            FaqCategory newFaqCategory= FaqCategoryConverter.toFaqCategory(requestDto, item, nextNum);
-            faqCategoryList.add(newFaqCategory);
-            item.getFaqCategoryList().add(newFaqCategory);
-        }
-
-        return faqCategoryRepository.saveAll(faqCategoryList);
+        return faqCategoryRepository.save(newFaqCategory);
     }
 
     @Override
@@ -71,24 +65,43 @@ public class FaqCategoryServiceImpl implements FaqCategoryService {
 
     @Override
     @Transactional
-    public void deleteAll(Long sellerId, Long itemId, List<FaqCategoryRequestDto.DeleteDto> requestList) {
+    public void delete(Long sellerId, Long itemId, FaqCategoryRequestDto.DeleteDto request) {
         if (!sellerRepository.existsById(sellerId)) throw new GeneralException(ErrorStatus.SELLER_NOT_FOUND);
         Item item = itemRepository.findById(itemId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.ITEM_NOT_FOUND));
 
-        for (FaqCategoryRequestDto.DeleteDto request : requestList) {
-            FaqCategory faqCategory = faqCategoryRepository.findById(request.getId())
-                    .orElseThrow(() -> new GeneralException(ErrorStatus.FAQ_CATEGORY_NOT_FOUND));
+        FaqCategory faqCategory = faqCategoryRepository.findById(request.getId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus.FAQ_CATEGORY_NOT_FOUND));
 
-            item.getFaqCategoryList().remove(faqCategory);
-            faqCategoryRepository.delete(faqCategory);
+        item.getFaqCategoryList().remove(faqCategory);
+        faqCardRepository.deleteAllByFaqCategory(faqCategory); // 해당 faq 카테고리에 있는 모든 faq 카드 삭제
+        faqCategoryRepository.delete(faqCategory);
+
+        // 순서 정리
+        List<FaqCategory> faqCategoryList = faqCategoryRepository.findAllByItemIdAndCategoryOrderAsc(itemId);
+        for (int i = 0; i < faqCategoryList.size(); i++) {
+            faqCategoryList.get(i).setCategoryOrder(i + 1);
+        }
+    }
+
+    @Override
+    @Transactional
+    public FaqCategory update(Long sellerId, Long itemId, FaqCategoryRequestDto.UpdateDto request) {
+        if (!sellerRepository.existsById(sellerId)) throw new GeneralException(ErrorStatus.SELLER_NOT_FOUND);
+        Item item = itemRepository.findById(itemId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.ITEM_NOT_FOUND));
+
+        FaqCategory faqCategory = faqCategoryRepository.findById(request.getId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus.FAQ_CATEGORY_NOT_FOUND));
+
+        if (!faqCategory.getItem().getId().equals(item.getId())) {
+            throw new GeneralException(ErrorStatus.INVALID_FAQ_ITEM_RELATION);
         }
 
-        List<FaqCategory> faqCategoryList = faqCategoryRepository.findAllByItemId(itemId);
-        for (int i=1; i<=faqCategoryList.size(); i++) {
-            FaqCategory faqCategory = faqCategoryList.get(i-1);
-            faqCategory.setCategoryOrder(i);
-        }
+        if (request.getCategory() != null) faqCategory.setCategory(request.getCategory());
+        faqCategoryRepository.save(faqCategory);
+
+        return faqCategory;
     }
 
     @Override

--- a/src/main/java/com/influy/domain/faqCategory/service/FaqCategoryServiceImpl.java
+++ b/src/main/java/com/influy/domain/faqCategory/service/FaqCategoryServiceImpl.java
@@ -65,7 +65,7 @@ public class FaqCategoryServiceImpl implements FaqCategoryService {
         if (!sellerRepository.existsById(sellerId)) throw new GeneralException(ErrorStatus.SELLER_NOT_FOUND);
         if (!itemRepository.existsById(itemId)) throw new GeneralException(ErrorStatus.ITEM_NOT_FOUND);
 
-        Pageable pageable = pageRequest.toPageable(Sort.by(Sort.Direction.ASC, "createdAt"));
+        Pageable pageable = pageRequest.toPageable(Sort.by(Sort.Direction.ASC, "categoryOrder"));
 
         return faqCategoryRepository.findAllByItemId(itemId, pageable);
     }
@@ -83,6 +83,12 @@ public class FaqCategoryServiceImpl implements FaqCategoryService {
 
             item.getFaqCategoryList().remove(faqCategory);
             faqCategoryRepository.delete(faqCategory);
+        }
+
+        List<FaqCategory> faqCategoryList = faqCategoryRepository.findAll();
+        for (int i=1; i<=faqCategoryList.size(); i++) {
+            FaqCategory faqCategory = faqCategoryList.get(i-1);
+            faqCategory.setCategoryOrder(i);
         }
     }
 
@@ -107,6 +113,15 @@ public class FaqCategoryServiceImpl implements FaqCategoryService {
             }
 
             if (request.getCategory() != null) faqCategory.setCategory(request.getCategory());
+            if (request.getCategoryOrder() != null) {
+                Integer newOrder = request.getCategoryOrder();
+                Integer oldOrder = faqCategory.getCategoryOrder();
+
+                if (!newOrder.equals(oldOrder)) {
+                    faqCategoryRepository.incrementOrdersFrom(item.getId(), newOrder, oldOrder);
+                    faqCategory.setCategoryOrder(newOrder);
+                }
+            }
 
             updatedList.add(faqCategory);
         }

--- a/src/main/java/com/influy/domain/faqCategory/service/FaqCategoryServiceImpl.java
+++ b/src/main/java/com/influy/domain/faqCategory/service/FaqCategoryServiceImpl.java
@@ -85,7 +85,7 @@ public class FaqCategoryServiceImpl implements FaqCategoryService {
             faqCategoryRepository.delete(faqCategory);
         }
 
-        List<FaqCategory> faqCategoryList = faqCategoryRepository.findAll();
+        List<FaqCategory> faqCategoryList = faqCategoryRepository.findAllByItemId(itemId);
         for (int i=1; i<=faqCategoryList.size(); i++) {
             FaqCategory faqCategory = faqCategoryList.get(i-1);
             faqCategory.setCategoryOrder(i);

--- a/src/main/java/com/influy/domain/faqCategory/service/FaqCategoryServiceImpl.java
+++ b/src/main/java/com/influy/domain/faqCategory/service/FaqCategoryServiceImpl.java
@@ -12,7 +12,6 @@ import com.influy.global.apiPayload.exception.GeneralException;
 import com.influy.global.common.PageRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
@@ -94,7 +93,7 @@ public class FaqCategoryServiceImpl implements FaqCategoryService {
 
     @Override
     @Transactional
-    public List<FaqCategory> updateAll(Long sellerId, Long itemId, List<FaqCategoryRequestDto.UpdateDto> requestList) {
+    public List<FaqCategory> updateOrderAll(Long sellerId, Long itemId, List<FaqCategoryRequestDto.UpdateOrderDto> requestList) {
         if (!sellerRepository.existsById(sellerId)) {
             throw new GeneralException(ErrorStatus.SELLER_NOT_FOUND);
         }
@@ -104,7 +103,7 @@ public class FaqCategoryServiceImpl implements FaqCategoryService {
 
         List<FaqCategory> updatedList = new ArrayList<>();
 
-        for (FaqCategoryRequestDto.UpdateDto request : requestList) {
+        for (FaqCategoryRequestDto.UpdateOrderDto request : requestList) {
             FaqCategory faqCategory = faqCategoryRepository.findById(request.getId())
                     .orElseThrow(() -> new GeneralException(ErrorStatus.FAQ_CATEGORY_NOT_FOUND));
 
@@ -112,7 +111,6 @@ public class FaqCategoryServiceImpl implements FaqCategoryService {
                 throw new GeneralException(ErrorStatus.INVALID_FAQ_ITEM_RELATION);
             }
 
-            if (request.getCategory() != null) faqCategory.setCategory(request.getCategory());
             if (request.getCategoryOrder() != null) {
                 Integer newOrder = request.getCategoryOrder();
                 Integer oldOrder = faqCategory.getCategoryOrder();

--- a/src/main/java/com/influy/global/config/SwaggerConfig.java
+++ b/src/main/java/com/influy/global/config/SwaggerConfig.java
@@ -33,7 +33,7 @@ public class SwaggerConfig {
                         .bearerFormat("JWT"));
 
         return new OpenAPI()
-                .addServersItem(new Server().url("api.influy.com/"))
+                .addServersItem(new Server().url("/"))
                 .info(info)
                 .addSecurityItem(securityRequirement)
                 .components(components);

--- a/src/main/java/com/influy/global/config/SwaggerConfig.java
+++ b/src/main/java/com/influy/global/config/SwaggerConfig.java
@@ -33,7 +33,7 @@ public class SwaggerConfig {
                         .bearerFormat("JWT"));
 
         return new OpenAPI()
-                .addServersItem(new Server().url("/"))
+                .addServersItem(new Server().url("api.influy.com/"))
                 .info(info)
                 .addSecurityItem(securityRequirement)
                 .components(components);


### PR DESCRIPTION
## 💜 Related Issue

> #51

## 💜 Work Details

> FAQ 카테고리 순서 수정이 가능하다고 하여 순서 필드 추가 및 crud에서도 잘 작동하도록 기능 수정했으요
> FAQ 카테고리 리스트 조회에서 원래는 등록순 정렬이었는데 이걸 카테고리 순서 기준 정렬하도록 바꿨습니당

## 💜 Review Requirement

> 테스트 완!
