### PR TITLE
#50 feat : 프론트가 인가코드 받게 수정

### DIFF
--- a/src/main/java/com/influy/global/auth/controller/AuthController.java
+++ b/src/main/java/com/influy/global/auth/controller/AuthController.java
@@ -3,10 +3,8 @@ package com.influy.global.auth.controller;
 import com.influy.global.apiPayload.ApiResponse;
 import com.influy.global.auth.dto.AuthResponseDTO;
 import com.influy.global.auth.service.AuthService;
-import com.influy.global.jwt.CookieUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -21,13 +19,12 @@ public class AuthController {
 
 
     @GetMapping("/kakao")
-    @Operation(summary = "카카오 서버에서 오는 redirect uri 받는 api 입니다. 프론트 사용 금지", description = "사용법: 최상단 명세서 설명란의 로그인 주소를 브라우저 주소창에 붙여넣기->응답으로 오는 카카오 아이디 복사->회원가입 api의 requestBody에 붙여넣기")
+    @Operation(summary = "카카로 로그인 후 토큰/회원가입 필요 메시지 get", description = "배포 서버는 기본적으로 프론트 로컬호스트로 redirect 하나, 바꾸고 싶을 경우 기재할 것. 단, 상단의 인가코드 받는 주소와 redirectUri가 동일해야함")
     public ApiResponse<AuthResponseDTO.KakaoLoginResponse> getKaKaoUser(@RequestParam("code") String code,
-                                                                        @RequestParam(name = "error", required = false) String error,
-                                                                        @RequestParam(name = "error_description", required = false) String description,
+                                                                        @RequestParam(name = "redirectionUri", required = false) String redirectionUri,
                                                                         HttpServletResponse response) {
 
-        AuthResponseDTO.KakaoLoginResponse body =  authService.SocialLogIn(code,response);
+        AuthResponseDTO.KakaoLoginResponse body =  authService.SocialLogIn(code,response, redirectionUri);
 
         return ApiResponse.onSuccess(body);
     }

--- a/src/main/java/com/influy/global/auth/service/AuthService.java
+++ b/src/main/java/com/influy/global/auth/service/AuthService.java
@@ -9,7 +9,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 public interface AuthService {
-    AuthResponseDTO.KakaoLoginResponse SocialLogIn(String code, HttpServletResponse response);
+    AuthResponseDTO.KakaoLoginResponse SocialLogIn(String code, HttpServletResponse response, String redirectionUri);
 
     Long GetSocialUserId(String accessToken);
 

--- a/src/main/java/com/influy/global/auth/service/KakaoAuthServiceImpl.java
+++ b/src/main/java/com/influy/global/auth/service/KakaoAuthServiceImpl.java
@@ -2,7 +2,6 @@ package com.influy.global.auth.service;
 
 import com.influy.domain.member.entity.Member;
 import com.influy.domain.member.repository.MemberRepository;
-import com.influy.domain.member.service.MemberService;
 import com.influy.global.apiPayload.code.status.ErrorStatus;
 import com.influy.global.apiPayload.exception.GeneralException;
 import com.influy.global.auth.TokenPair;
@@ -44,8 +43,13 @@ public class KakaoAuthServiceImpl implements AuthService {
     private String kakaoAdminKey;
 
     @Override
-    public AuthResponseDTO.KakaoLoginResponse SocialLogIn(String code, HttpServletResponse response) {
+    public AuthResponseDTO.KakaoLoginResponse SocialLogIn(String code, HttpServletResponse response, String redirectionUri) {
 
+        //배포 리디렉션은 기본적으로 프론트 로컬을 기본으로 하고,
+        //로컬 리디렉션은 프론트 배포 주소를 기본으로 하도록 설정
+        if(redirectionUri==null){
+            redirectionUri = redirectUri;
+        }
 
         //토큰 받기 POST 요청
 


### PR DESCRIPTION
## 💜 Related Issue

> #50 

## 💜 Work Details

> 오늘내로 해달라해서 이거만 따로 뺐스빈당

## 💜 Review Requirement

>바뀐 사항: application.yml 에서 redirectUri를 https://influy.com/oauth/kakao/callback으로 바꿔주세요.
프론트 배포 완성될때까지 프론트 로컬로 리디렉션 해달라는 요청이 있어서 prod에서는 프론트 로컬(localhostL5173)으로 합니다.

>로컬 호스트에서 테스트 시, 예전과 같이 스웨거 상단의 주소 긁어서 로그인 하면 프론트 배포 사이트가 뜹니다. 404에러 나있지만 신경쓰지 말고 주소창의 code 파라미터 값 긁어서 스웨거 맨 아래 auth/kakao api 의 파라미터에 붙여넣어 사용합니다.

> 혹시나 백엔드도 배포 버전에서 테스트 해봐야할 일이 있을까봐 기본 값은 yml 기준으로 하되, 옵션으로 parameter를 통해 redirectUri를 바꿀 수 있도록 했습니다.
