### PR TITLE
#63 Feature: 셀러뷰 질문별 질문 조회 기능 구현

### DIFF
--- a/src/main/java/com/influy/domain/ai/service/AiService.java
+++ b/src/main/java/com/influy/domain/ai/service/AiService.java
@@ -4,8 +4,10 @@ import com.influy.domain.item.entity.Item;
 import com.influy.domain.questionCategory.entity.QuestionCategory;
 import com.influy.domain.questionTag.entity.QuestionTag;
 
+import java.util.List;
+
 public interface AiService {
-    void generateCategory(Item item);
+    List<String> generateCategory(Item item);
 
     QuestionTag classifyQuestion(String content, QuestionCategory questionCategory);
 }

--- a/src/main/java/com/influy/domain/ai/service/AiServiceImpl.java
+++ b/src/main/java/com/influy/domain/ai/service/AiServiceImpl.java
@@ -17,15 +17,18 @@ import com.influy.domain.questionTag.repository.QuestionTagRepository;
 import com.influy.domain.questionTag.service.QuestionTagService;
 import com.influy.global.apiPayload.code.status.ErrorStatus;
 import com.influy.global.apiPayload.exception.GeneralException;
+import org.springframework.core.io.Resource;
 import lombok.RequiredArgsConstructor;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.ai.chat.client.ChatClient;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.*;
@@ -43,8 +46,8 @@ public class AiServiceImpl implements AiService {
     private final QuestionTagService questionTagService;
     private final QuestionTagRepository questionTagRepository;
 
-    private static final String CATEGORY_PROMPT_FILE_PATH = "src/main/resources/category-storage/aiQuestionCategory/prompt-question-category.txt";
-    private static final String QUESTION_CLASSIFICATION_FILE_PATH = "src/main/resources/category-storage/aiQuestionClassification/system-prompt.txt";
+    private static final String CATEGORY_PROMPT_FILE_PATH = "category-storage/aiQuestionCategory/prompt-question-category.txt";
+    private static final String QUESTION_CLASSIFICATION_FILE_PATH = "category-storage/aiQuestionClassification/system-prompt.txt";
 
     @Override
     @Transactional
@@ -111,7 +114,8 @@ public class AiServiceImpl implements AiService {
                                                List<AiRequestDTO.Question> questionDTOs) throws IOException {
 
         try {
-            String template = Files.readString(Paths.get(QUESTION_CLASSIFICATION_FILE_PATH));
+            Resource resource = new ClassPathResource(QUESTION_CLASSIFICATION_FILE_PATH);
+            String template = new String(resource.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
             return template
                     .replace("{{questioncategoryname}}", questionCategoryName)
                     .replace("{{questiontagdtolist}}", objectMapper.writeValueAsString(questionTagDTOs))
@@ -122,9 +126,10 @@ public class AiServiceImpl implements AiService {
         }
     }
 
-    private String buildPromptCategory(Item item) throws IOException{
+    private String buildPromptCategory(Item item) throws IOException {
         try {
-            String template = Files.readString(Paths.get(CATEGORY_PROMPT_FILE_PATH));
+            Resource resource = new ClassPathResource(CATEGORY_PROMPT_FILE_PATH);
+            String template = new String(resource.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
             return template
                     .replace("{{name}}", item.getName())
                     .replace("{{categories}}", item.getItemCategoryList().stream()

--- a/src/main/java/com/influy/domain/ai/service/AiServiceImpl.java
+++ b/src/main/java/com/influy/domain/ai/service/AiServiceImpl.java
@@ -45,7 +45,6 @@ public class AiServiceImpl implements AiService {
     private final QuestionTagRepository questionTagRepository;
 
     private static final String CATEGORY_PROMPT_FILE_PATH = "src/main/resources/category-storage/aiQuestionCategory/prompt-question-category.txt";
-//    private static final String CATEGORY_JSON_FILE_PATH = "src/main/resources/category-storage/question-category.json";
     private static final String QUESTION_CLASSIFICATION_FILE_PATH = "src/main/resources/category-storage/aiQuestionClassification/system-prompt.txt";
 
     @Override
@@ -154,22 +153,6 @@ public class AiServiceImpl implements AiService {
 
     }
 
-
-//    private void updateQuestionsToNewTag(Item item, List<String> aiCategories) throws IOException {
-//
-//        //기본 대분류
-//        List<String> defaultCategoryList = Arrays.stream(DEFAULT_QUESTION_CATEGORIES).toList();
-//        //ai 생성 카테고리에 더하기
-//        aiCategories.addAll(defaultCategoryList);
-//
-//        for (String name:aiCategories) {
-//            if (!questionCategoryRepository.existsByItemIdAndName(item.getId(), name.trim())) {
-//                QuestionCategory category = QuestionCategoryConverter.toQuestionCategory(item, name.trim());
-//                //각 카테고리마다 기타 태그 기본으로 생성
-//                category.getQuestionTagList().add(QuestionTagConverter.toQuestionTag("기타", category));
-//            }
-//        }
-//    }
 
     private void updateQuestionsToNewTag(AiResponseDTO.QuestionClassification result,
                                          QuestionTag createdTag, Map<Long,QuestionTag> questionTagMap,

--- a/src/main/java/com/influy/domain/ai/service/AiServiceImpl.java
+++ b/src/main/java/com/influy/domain/ai/service/AiServiceImpl.java
@@ -40,12 +40,10 @@ import static com.influy.global.util.StaticValues.DEFAULT_QUESTION_CATEGORIES;
 public class AiServiceImpl implements AiService {
     private final ObjectMapper objectMapper;
     private final ChatClient chatClient;
-    private final QuestionCategoryRepository questionCategoryRepository;
     private final QuestionTagService questionTagService;
     private final QuestionTagRepository questionTagRepository;
 
     private static final String CATEGORY_PROMPT_FILE_PATH = "src/main/resources/category-storage/aiQuestionCategory/prompt-question-category.txt";
-//    private static final String CATEGORY_JSON_FILE_PATH = "src/main/resources/category-storage/question-category.json";
     private static final String QUESTION_CLASSIFICATION_FILE_PATH = "src/main/resources/category-storage/aiQuestionClassification/system-prompt.txt";
 
     @Override
@@ -153,23 +151,6 @@ public class AiServiceImpl implements AiService {
                 .trim();
 
     }
-
-
-//    private void updateQuestionsToNewTag(Item item, List<String> aiCategories) throws IOException {
-//
-//        //기본 대분류
-//        List<String> defaultCategoryList = Arrays.stream(DEFAULT_QUESTION_CATEGORIES).toList();
-//        //ai 생성 카테고리에 더하기
-//        aiCategories.addAll(defaultCategoryList);
-//
-//        for (String name:aiCategories) {
-//            if (!questionCategoryRepository.existsByItemIdAndName(item.getId(), name.trim())) {
-//                QuestionCategory category = QuestionCategoryConverter.toQuestionCategory(item, name.trim());
-//                //각 카테고리마다 기타 태그 기본으로 생성
-//                category.getQuestionTagList().add(QuestionTagConverter.toQuestionTag("기타", category));
-//            }
-//        }
-//    }
 
     private void updateQuestionsToNewTag(AiResponseDTO.QuestionClassification result,
                                          QuestionTag createdTag, Map<Long,QuestionTag> questionTagMap,

--- a/src/main/java/com/influy/domain/answer/controller/AnswerRestController.java
+++ b/src/main/java/com/influy/domain/answer/controller/AnswerRestController.java
@@ -54,32 +54,4 @@ public class AnswerRestController {
         Answer answer = answerService.createIndividualAnswer(userDetails, itemId, questionCategoryId, questionTagId, questionId, request, answerType);
         return ApiResponse.onSuccess(AnswerConverter.toAnswerResultDto(answer));
     }
-
-    @DeleteMapping("/{questionCategoryId}/questions")
-    @Operation(summary = "선택한 질문들 삭제 (여러개 가능, 질문 객체 삭제가 아닌 isHidden 처리)")
-    public ApiResponse<AnswerResponseDto.DeleteResultDto> delete(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                                                 @PathVariable("itemId") Long itemId,
-                                                                 @PathVariable("questionCategoryId") Long questionCategoryId,
-                                                                 @RequestBody @Valid AnswerRequestDto.DeleteDto request) {
-        return ApiResponse.onSuccess(answerService.delete(userDetails, itemId, questionCategoryId, request));
-    }
-
-//    @GetMapping("/{questionCategoryId}/questions/{questionTagId}/{questionId}")
-//    @Operation(summary = "개별 질문 + 답변들 조회 (아직 구현 x)")
-//    public ApiResponse<AnswerResponseDto.QnAListDto> viewQnA(@AuthenticationPrincipal CustomUserDetails userDetails,
-//                                                             @PathVariable("itemId") Long itemId,
-//                                                             @PathVariable("questionCategoryId") Long questionCategoryId,
-//                                                             @PathVariable("questionTagId") Long questionTagId,
-//                                                             @PathVariable("questionId") Long questionId) {
-//        return ApiResponse.onSuccess(SuccessStatus._OK);
-//    }
-
-
-    @PostMapping("/open-status")
-    @Operation(summary = "톡박스 오픈 여부 수정")
-    public ApiResponse<AnswerResponseDto.TalkBoxOpenStatusDto> changeOpenStatus(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                                                          @PathVariable("itemId") Long itemId,
-                                                                          @RequestParam(name = "openStatus", defaultValue = "OPENED") TalkBoxOpenStatus openStatus) {
-        return ApiResponse.onSuccess(answerService.changeOpenStatus(userDetails, itemId, openStatus));
-    }
 }

--- a/src/main/java/com/influy/domain/answer/converter/AnswerConverter.java
+++ b/src/main/java/com/influy/domain/answer/converter/AnswerConverter.java
@@ -7,7 +7,9 @@ import com.influy.domain.item.entity.Item;
 import com.influy.domain.item.entity.TalkBoxOpenStatus;
 import com.influy.domain.question.entity.Question;
 import com.influy.domain.questionTag.entity.QuestionTag;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public class AnswerConverter {
@@ -46,16 +48,20 @@ public class AnswerConverter {
                 .build();
     }
 
-    public static AnswerResponseDto.DeleteResultDto toDeleteResultDto(List<Long> questionList) {
-        return AnswerResponseDto.DeleteResultDto.builder()
-                .questionIdList(questionList)
+
+    public static AnswerResponseDto.AnswerViewDto toAnswerViewDto(Answer answer) {
+        return AnswerResponseDto.AnswerViewDto.builder()
+                .answerId(answer.getId())
+                .answerType(answer.getAnswerType())
+                .answerContent(answer.getContent())
+                .answerTime(answer.getCreatedAt())
                 .build();
     }
 
-    public static AnswerResponseDto.TalkBoxOpenStatusDto toTalkBoxOpenStatusDto(Long itemId, TalkBoxOpenStatus openStatus) {
-        return AnswerResponseDto.TalkBoxOpenStatusDto.builder()
-                .itemId(itemId)
-                .status(openStatus)
-                .build();
+    public static AnswerResponseDto.AnswerViewListDto toAnswerViewListDto(List<Answer> answerList) {
+        List<AnswerResponseDto.AnswerViewDto> answerDtoList = answerList.stream().map(AnswerConverter::toAnswerViewDto).toList();
+
+        return AnswerResponseDto.AnswerViewListDto.builder()
+                .answerViewList(answerDtoList).build();
     }
 }

--- a/src/main/java/com/influy/domain/answer/dto/AnswerRequestDto.java
+++ b/src/main/java/com/influy/domain/answer/dto/AnswerRequestDto.java
@@ -20,10 +20,4 @@ public class AnswerRequestDto {
         @Schema(description = "답변 내용", example = "이건 이거임당")
         private String answerContent;
     }
-
-    @Getter
-    public static class DeleteDto {
-        @Schema(description = "삭제할 질문 id 리스트 (1개도 가능)", example = "[1, 2]")
-        private List<Long> questionIdList;
-    }
 }

--- a/src/main/java/com/influy/domain/answer/dto/AnswerResponseDto.java
+++ b/src/main/java/com/influy/domain/answer/dto/AnswerResponseDto.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public class AnswerResponseDto {
@@ -51,35 +52,30 @@ public class AnswerResponseDto {
         private AnswerType answerType;
     }
 
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AnswerViewListDto {
+        @Schema(description = "답변 리스트")
+        private List<AnswerViewDto> answerViewList;
+    }
 
     @Getter
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class DeleteResultDto {
-        @Schema(description = "삭제된 질문 id 리스트")
-        private List<Long> questionIdList;
+    public static class AnswerViewDto {
+        @Schema(description = "답변 id", example = "1")
+        private Long answerId;
+
+        @Schema(description = "답변 타입 [COMMON, INDIVIDUAL, FAQ", example = "INDIVIDUAL")
+        private AnswerType answerType;
+
+        @Schema(description = "답변 내용", example = "울랄라 이건 이거에요")
+        private String answerContent;
+
+        @Schema(description = "답변 생성일", example = "021-01-01T00:00")
+        private LocalDateTime answerTime;
     }
-
-//    @Getter
-//    @Builder
-//    @NoArgsConstructor
-//    @AllArgsConstructor
-//    public static class QnAListDto {
-//
-//    }
-
-
-    @Getter
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class TalkBoxOpenStatusDto {
-        @Schema(description = "아이템 id", example = "1")
-        private Long itemId;
-
-        @Schema(description = "해당 톡박스 상태 [INITIAL, OPENED, CLOSED]", example = "OPENED")
-        private TalkBoxOpenStatus status;
-    }
-
 }

--- a/src/main/java/com/influy/domain/answer/service/AnswerService.java
+++ b/src/main/java/com/influy/domain/answer/service/AnswerService.java
@@ -12,6 +12,4 @@ public interface AnswerService {
     Answer createIndividualAnswer(CustomUserDetails userDetails, Long itemId, Long questionCategoryId, Long questionTagId, Long questionId, AnswerRequestDto.AnswerIndividualDto request, AnswerType answerType);
     AnswerResponseDto.AnswerTagListDto getList(CustomUserDetails userDetails, Long itemId, Long questionCategoryId, Long questionTagId);
     AnswerResponseDto.AnswerCommonResultDto createCommonAnswers(CustomUserDetails userDetails, Long itemId, Long questionCategoryId, AnswerRequestDto.AnswerCommonDto request);
-    AnswerResponseDto.DeleteResultDto delete(CustomUserDetails userDetails, Long itemId, Long questionCategoryId, AnswerRequestDto.DeleteDto request);
-    AnswerResponseDto.TalkBoxOpenStatusDto changeOpenStatus(CustomUserDetails userDetails, Long itemId, TalkBoxOpenStatus openStatus);
 }

--- a/src/main/java/com/influy/domain/answer/service/AnswerServiceImpl.java
+++ b/src/main/java/com/influy/domain/answer/service/AnswerServiceImpl.java
@@ -87,34 +87,6 @@ public class AnswerServiceImpl implements AnswerService {
         return AnswerConverter.toAnswerCommonResultDto(answerList.size(), answerList);
     }
 
-    @Override
-    @Transactional
-    public AnswerResponseDto.DeleteResultDto delete(CustomUserDetails userDetails, Long itemId, Long questionCategoryId, AnswerRequestDto.DeleteDto request) {
-        memberService.checkSeller(userDetails);
-
-        // 질문을 삭제하면 해당 질문의 모든 답변들도 삭제된다고 가정 (셀러 입장)
-        List<Question> questionList= questionRepository.findAllById(request.getQuestionIdList());
-        for (Question question : questionList) {
-            question.setIsHidden(true);
-        }
-
-        return AnswerConverter.toDeleteResultDto(request.getQuestionIdList());
-    }
-
-    @Override
-    @Transactional
-    public AnswerResponseDto.TalkBoxOpenStatusDto changeOpenStatus(CustomUserDetails userDetails, Long itemId, TalkBoxOpenStatus openStatus) {
-        memberService.checkSeller(userDetails);
-        Item item = itemRepository.findById(itemId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.ITEM_NOT_FOUND));
-
-        if (openStatus == TalkBoxOpenStatus.INITIAL) throw new GeneralException((ErrorStatus.INVALID_TALKBOX_REQUEST));
-        item.setTalkBoxOpenStatus(openStatus);
-
-        return AnswerConverter.toTalkBoxOpenStatusDto(itemId, openStatus);
-    }
-
-
     private Item checkTalkBoxOpenStatus(Long itemId) {
         Item item = itemRepository.findById(itemId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.ITEM_NOT_FOUND));

--- a/src/main/java/com/influy/domain/item/controller/ItemRestController.java
+++ b/src/main/java/com/influy/domain/item/controller/ItemRestController.java
@@ -34,15 +34,15 @@ public class ItemRestController {
     }
 
     @GetMapping("/{sellerId}/items")
-    @Operation(summary = "셀러의 상품 상세정보 프리뷰 리스트 조회 (공개/아카이브/진행중 여부 선택 가능)", description = "memberId는 이후 AuthenticationPrincipal로 받을 것")
-    public ApiResponse<ItemResponseDto.DetailPreviewPageDto> getDetailPreviewPage(@PathVariable("sellerId") Long sellerId,
+    @Operation(summary = "셀러의 상품 상세정보 프리뷰 리스트 조회 (공개/아카이브/진행중 여부 선택 가능)")
+    public ApiResponse<ItemResponseDto.DetailPreviewPageDto> getDetailPreviewPage(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                                                    @PathVariable("sellerId") Long sellerId,
                                                                                   @RequestParam(name = "archive", defaultValue = "false") Boolean isArchived,
                                                                                   @Valid @ParameterObject PageRequestDto pageRequest,
                                                                                   @RequestParam(name = "sortType", defaultValue = "END_DATE") ItemSortType sortType,
-                                                                                  @RequestParam(name = "onGoing", defaultValue = "false") Boolean isOnGoing,
-                                                                                  @RequestParam(value = "memberId", required = false) Long memberId) {
+                                                                                  @RequestParam(name = "onGoing", defaultValue = "false") Boolean isOnGoing) {
 
-        return ApiResponse.onSuccess(itemService.getDetailPreviewPage(sellerId, isArchived, pageRequest, sortType, isOnGoing, memberId));
+        return ApiResponse.onSuccess(itemService.getDetailPreviewPage(userDetails, sellerId, isArchived, pageRequest, sortType, isOnGoing));
     }
 
     @GetMapping("/{sellerId}/items/{itemId}")
@@ -125,5 +125,11 @@ public class ItemRestController {
     public ApiResponse<ItemResponseDto.ViewTalkBoxCommentDto> getTalkBoxComment(@AuthenticationPrincipal CustomUserDetails userDetails,
                                                                             @PathVariable("itemId") Long itemId) {
         return ApiResponse.onSuccess(itemService.getTalkBoxComment(userDetails, itemId));
+    }
+
+    @GetMapping("/talkbox/opened")
+    @Operation(summary = "전체 질문 관리창 = 톡박스", description = "톡박스 활성화된 상품 리스트 조회")
+    public ApiResponse<ItemResponseDto.TalkBoxOpenedListDto> getTalkBoxOpened (@AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ApiResponse.onSuccess(itemService.getTalkBoxOpened(userDetails));
     }
 }

--- a/src/main/java/com/influy/domain/item/controller/ItemRestController.java
+++ b/src/main/java/com/influy/domain/item/controller/ItemRestController.java
@@ -1,7 +1,5 @@
 package com.influy.domain.item.controller;
 
-import com.influy.domain.answer.dto.AnswerResponseDto;
-import com.influy.domain.faqCard.dto.FaqCardResponseDto;
 import com.influy.domain.item.converter.ItemConverter;
 import com.influy.domain.item.dto.ItemRequestDto;
 import com.influy.domain.item.dto.ItemResponseDto;
@@ -17,7 +15,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
-import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -115,7 +112,7 @@ public class ItemRestController {
     }
 
 
-    @PutMapping("/items/{itemId}/talkbox/default-comment")
+    @PatchMapping("/items/{itemId}/talkbox/default-comment")
     @Operation(summary = "톡박스 기본 멘트 등록")
     public ApiResponse<ItemResponseDto.ResultDto> updateTalkBoxComment(@AuthenticationPrincipal CustomUserDetails userDetails,
                                                                               @PathVariable("itemId") Long itemId,
@@ -123,5 +120,10 @@ public class ItemRestController {
         return ApiResponse.onSuccess(itemService.updateTalkBoxComment(userDetails, itemId, request));
     }
 
-    // 톡박스 기본 멘트 미리보기 조회
+    @GetMapping("/items/{itemId}/talkbox/view-comment")
+    @Operation(summary = "톡박스 기본 멘트 미리보기 조회")
+    public ApiResponse<ItemResponseDto.ViewTalkBoxCommentDto> getTalkBoxComment(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                                            @PathVariable("itemId") Long itemId) {
+        return ApiResponse.onSuccess(itemService.getTalkBoxComment(userDetails, itemId));
+    }
 }

--- a/src/main/java/com/influy/domain/item/controller/ItemRestController.java
+++ b/src/main/java/com/influy/domain/item/controller/ItemRestController.java
@@ -113,4 +113,15 @@ public class ItemRestController {
                                                                                 @RequestParam(name = "openStatus", defaultValue = "OPENED") TalkBoxOpenStatus openStatus) {
         return ApiResponse.onSuccess(itemService.changeOpenStatus(userDetails, itemId, openStatus));
     }
+
+
+    @PutMapping("/items/{itemId}/talkbox/default-comment")
+    @Operation(summary = "톡박스 기본 멘트 등록")
+    public ApiResponse<ItemResponseDto.ResultDto> updateTalkBoxComment(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                                              @PathVariable("itemId") Long itemId,
+                                                                              @RequestBody @Valid ItemRequestDto.TalkBoxCommentDto request) {
+        return ApiResponse.onSuccess(itemService.updateTalkBoxComment(userDetails, itemId, request));
+    }
+
+    // 톡박스 기본 멘트 미리보기 조회
 }

--- a/src/main/java/com/influy/domain/item/controller/ItemRestController.java
+++ b/src/main/java/com/influy/domain/item/controller/ItemRestController.java
@@ -1,10 +1,12 @@
 package com.influy.domain.item.controller;
 
+import com.influy.domain.answer.dto.AnswerResponseDto;
 import com.influy.domain.faqCard.dto.FaqCardResponseDto;
 import com.influy.domain.item.converter.ItemConverter;
 import com.influy.domain.item.dto.ItemRequestDto;
 import com.influy.domain.item.dto.ItemResponseDto;
 import com.influy.domain.item.entity.Item;
+import com.influy.domain.item.entity.TalkBoxOpenStatus;
 import com.influy.domain.item.service.ItemService;
 import com.influy.domain.sellerProfile.entity.ItemSortType;
 import com.influy.global.apiPayload.ApiResponse;
@@ -102,5 +104,13 @@ public class ItemRestController {
     public ApiResponse<ItemResponseDto.ItemOverviewDto> getItemInfo(@PathVariable("sellerId") Long sellerId,
                                                                    @PathVariable("itemId") Long itemId) {
         return ApiResponse.onSuccess(itemService.getItemOverview(sellerId, itemId));
+    }
+
+    @PostMapping("/items/{itemId}/talkbox/open-status")
+    @Operation(summary = "톡박스 오픈 여부 수정")
+    public ApiResponse<ItemResponseDto.TalkBoxOpenStatusDto> changeOpenStatus(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                                                @PathVariable("itemId") Long itemId,
+                                                                                @RequestParam(name = "openStatus", defaultValue = "OPENED") TalkBoxOpenStatus openStatus) {
+        return ApiResponse.onSuccess(itemService.changeOpenStatus(userDetails, itemId, openStatus));
     }
 }

--- a/src/main/java/com/influy/domain/item/converter/ItemConverter.java
+++ b/src/main/java/com/influy/domain/item/converter/ItemConverter.java
@@ -1,10 +1,12 @@
 package com.influy.domain.item.converter;
 
+import com.influy.domain.answer.dto.AnswerResponseDto;
 import com.influy.domain.faqCard.dto.FaqCardResponseDto;
 import com.influy.domain.item.dto.ItemRequestDto;
 import com.influy.domain.item.dto.ItemResponseDto;
 import com.influy.domain.item.entity.Item;
 import com.influy.domain.image.entity.Image;
+import com.influy.domain.item.entity.TalkBoxOpenStatus;
 import com.influy.domain.member.entity.MemberRole;
 import com.influy.domain.sellerProfile.entity.SellerProfile;
 import org.springframework.data.domain.Page;
@@ -123,6 +125,13 @@ public class ItemConverter {
                 .tagline(item.getTagline())
                 .mainImg(item.getImageList().getFirst().getImageLink())
                 .talkBoxOpenStatus(item.getTalkBoxOpenStatus())
+                .build();
+    }
+
+    public static ItemResponseDto.TalkBoxOpenStatusDto toTalkBoxOpenStatusDto(Long itemId, TalkBoxOpenStatus openStatus) {
+        return ItemResponseDto.TalkBoxOpenStatusDto.builder()
+                .itemId(itemId)
+                .status(openStatus)
                 .build();
     }
 }

--- a/src/main/java/com/influy/domain/item/converter/ItemConverter.java
+++ b/src/main/java/com/influy/domain/item/converter/ItemConverter.java
@@ -11,6 +11,7 @@ import com.influy.domain.member.entity.MemberRole;
 import com.influy.domain.sellerProfile.entity.SellerProfile;
 import org.springframework.data.domain.Page;
 
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -132,6 +133,17 @@ public class ItemConverter {
         return ItemResponseDto.TalkBoxOpenStatusDto.builder()
                 .itemId(itemId)
                 .status(openStatus)
+                .build();
+    }
+
+    public static ItemResponseDto.ViewTalkBoxCommentDto toViewTalkBoxCommentDto(SellerProfile seller, Item item) {
+        return ItemResponseDto.ViewTalkBoxCommentDto.builder()
+                .sellerId(seller.getId())
+                .sellerProfileImg(seller.getMember() == null ? null : seller.getMember().getProfileImg())
+                .sellerUsername(seller.getMember() == null ? null : seller.getMember().getUsername())
+                .sellerNickname(seller.getMember() == null ? null : seller.getMember().getNickname())
+                .createdAt(LocalDateTime.now())
+                .talkBoxComment(item.getTalkBoxComment())
                 .build();
     }
 }

--- a/src/main/java/com/influy/domain/item/converter/ItemConverter.java
+++ b/src/main/java/com/influy/domain/item/converter/ItemConverter.java
@@ -6,14 +6,18 @@ import com.influy.domain.item.dto.ItemRequestDto;
 import com.influy.domain.item.dto.ItemResponseDto;
 import com.influy.domain.item.entity.Item;
 import com.influy.domain.image.entity.Image;
+import com.influy.domain.item.entity.TalkBoxInfoPair;
 import com.influy.domain.item.entity.TalkBoxOpenStatus;
+import com.influy.domain.member.entity.Member;
 import com.influy.domain.member.entity.MemberRole;
 import com.influy.domain.sellerProfile.entity.SellerProfile;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.springframework.data.domain.Page;
 
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public class ItemConverter {
@@ -45,7 +49,7 @@ public class ItemConverter {
                 .build();
     }
 
-    public static ItemResponseDto.DetailPreviewDto toDetailPreviewDto(Item item, boolean liked, MemberRole memberRole) {
+    public static ItemResponseDto.DetailPreviewDto toDetailPreviewDto(Item item, boolean liked, MemberRole memberRole, Integer waitingCnt, Integer completedCnt) {
         return ItemResponseDto.DetailPreviewDto.builder()
                 .itemId(item.getId())
                 .sellerId(item.getSeller().getId())
@@ -58,15 +62,21 @@ public class ItemConverter {
                 .tagline(item.getTagline())
                 .currentStatus(item.getItemStatus())
                 .liked(liked)
-                .talkBoxInfo(memberRole==MemberRole.SELLER ? toTalkBoxInfoDto(item):null)
+                .talkBoxInfo(memberRole==MemberRole.SELLER ? toTalkBoxInfoDto(item, waitingCnt, completedCnt):null)
                 .build();
     }
 
-    public static ItemResponseDto.DetailPreviewPageDto toDetailPreviewPageDto(Page<Item> itemPage, List<Long> likeItems, MemberRole memberRole) {
+    public static ItemResponseDto.DetailPreviewPageDto toDetailPreviewPageDto(Page<Item> itemPage, List<Long> likeItems, MemberRole memberRole, Map<Long, Integer> waitingCntMap, Map<Long, Integer> completedCntMap) {
         List<Long> safeLikeItems = (likeItems != null) ? likeItems : Collections.emptyList();
 
         List<ItemResponseDto.DetailPreviewDto> itemPreviewList = itemPage.stream()
-                .map(item -> toDetailPreviewDto(item, safeLikeItems.contains(item.getId()), memberRole))
+                .map(item -> {
+                    Long itemId = item.getId();
+                    boolean liked = safeLikeItems.contains(item.getId());
+                    Integer waitingCnt = waitingCntMap.getOrDefault(itemId, 0);
+                    Integer completedCnt = completedCntMap.getOrDefault(itemId, 0);
+                    return toDetailPreviewDto(item, liked, memberRole, waitingCnt, completedCnt);
+                })
                 .toList();
 
         return ItemResponseDto.DetailPreviewPageDto.builder()
@@ -79,11 +89,11 @@ public class ItemConverter {
                 .build();
     }
 
-    public static ItemResponseDto.TalkBoxInfoDto toTalkBoxInfoDto(Item item) {
+    public static ItemResponseDto.TalkBoxInfoDto toTalkBoxInfoDto(Item item, Integer waitingCnt, Integer completedCnt) {
         return ItemResponseDto.TalkBoxInfoDto.builder()
                 .talkBoxOpenStatus(item.getTalkBoxOpenStatus())
-                .waitingCnt(0)
-                .completedCnt(0)
+                .waitingCnt(waitingCnt)
+                .completedCnt(completedCnt)
                 .build();
     }
 
@@ -137,13 +147,41 @@ public class ItemConverter {
     }
 
     public static ItemResponseDto.ViewTalkBoxCommentDto toViewTalkBoxCommentDto(SellerProfile seller, Item item) {
+        Member member = seller.getMember();
         return ItemResponseDto.ViewTalkBoxCommentDto.builder()
                 .sellerId(seller.getId())
-                .sellerProfileImg(seller.getMember() == null ? null : seller.getMember().getProfileImg())
-                .sellerUsername(seller.getMember() == null ? null : seller.getMember().getUsername())
-                .sellerNickname(seller.getMember() == null ? null : seller.getMember().getNickname())
+                .sellerProfileImg(member.getProfileImg())
+                .sellerUsername(member.getUsername())
+                .sellerNickname(member.getNickname())
                 .createdAt(LocalDateTime.now())
                 .talkBoxComment(item.getTalkBoxComment())
+                .build();
+    }
+
+    public static ItemResponseDto.TalkBoxOpenedDto toTalkBoxOpenedDto(Item item, Integer waitingCnt, Integer completedCnt, Integer unCheckedCnt) {
+        return ItemResponseDto.TalkBoxOpenedDto.builder()
+                .itemId(item.getId())
+                .itemMainImg(item.getImageList().getFirst().getImageLink())
+                .itemName(item.getName())
+                .talkBoxCntInfo(toTalkBoxInfoDto(item, waitingCnt, completedCnt))
+                .newCnt(unCheckedCnt)
+                .build();
+    }
+
+    public static ItemResponseDto.TalkBoxOpenedListDto toTalkBoxOpenedListDto(List<Item> itemList, Map<Long, Integer> waitingCntMap, Map<Long, Integer> completedCntMap, Map<Long, Integer> unCheckedCntMap) {
+        List<ItemResponseDto.TalkBoxOpenedDto> itemDtoList = itemList.stream()
+                .map(item -> {
+                    Long itemId = item.getId();
+                    Integer waitingCnt = waitingCntMap.getOrDefault(itemId, 0);
+                    Integer completedCnt = completedCntMap.getOrDefault(itemId, 0);
+                    Integer unCheckedCnt = unCheckedCntMap.getOrDefault(itemId, 0);
+                    return toTalkBoxOpenedDto(item, waitingCnt, completedCnt, unCheckedCnt);
+                })
+                .toList();
+
+        return ItemResponseDto.TalkBoxOpenedListDto.builder()
+                .cnt(itemList.size())
+                .talkBoxOpenedDtoList(itemDtoList)
                 .build();
     }
 }

--- a/src/main/java/com/influy/domain/item/dto/ItemRequestDto.java
+++ b/src/main/java/com/influy/domain/item/dto/ItemRequestDto.java
@@ -13,9 +13,6 @@ import java.util.List;
 
 public class ItemRequestDto {
     @Getter
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
     public static class DetailDto {
         @Schema(description = "아이템 사진 리스트, 대표사진은 리스트 맨 처음 순서로", example = "[\"xxx.png\", \"xxxxx.png\", \"xxxxxx.png\"]")
         @Size(max = 10, message = "이미지는 최대 10개까지만 업로드할 수 있습니다.")
@@ -57,9 +54,6 @@ public class ItemRequestDto {
     }
 
     @Getter
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
     public static class AccessDto {
         @Schema(description = "홈아카이브 추천 허용", example = "false")
         private Boolean archiveRecommended;
@@ -69,11 +63,14 @@ public class ItemRequestDto {
     }
 
     @Getter
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
     public static class StatusDto {
         @Schema(description = "아이템 표기 상태", example = "SOLD_OUT")
         private ItemStatus status;
+    }
+
+    @Getter
+    public static class TalkBoxCommentDto {
+        @Schema(description = "톡박스 기본 멘트", example = "FAQ를 보고도 해결되지 않는 부분을 이곳에 남겨주시면 최대한 빠르게 답변 드리겠습니다!")
+        private String talkBoxComment;
     }
 }

--- a/src/main/java/com/influy/domain/item/dto/ItemResponseDto.java
+++ b/src/main/java/com/influy/domain/item/dto/ItemResponseDto.java
@@ -206,7 +206,40 @@ public class ItemResponseDto {
         @Schema(description = "생성일", example = "021-01-01T00:00")
         private LocalDateTime createdAt;
 
-        @Schema(description = "톡박스 기본 멘트", example = "울랄라 먐마먀")
+        @Schema(description = "톡박스 기본 멘트", example = "울랄라 먐마미아")
         private String talkBoxComment;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TalkBoxOpenedListDto {
+        @Schema(description = "톡박스가 활성화된 아이템 리스트")
+        private List<TalkBoxOpenedDto> talkBoxOpenedDtoList;
+
+        @Schema(description = "톡박스가 활성화된 아이템 개수", example = "4")
+        private Integer cnt;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TalkBoxOpenedDto {
+        @Schema(description = "아이템 id", example = "1")
+        private Long itemId;
+
+        @Schema(description = "아이템 대표사진", example = "https:/....")
+        private String itemMainImg;
+
+        @Schema(description = "아이템 이름", example = "컬러 리들샷")
+        private String itemName;
+
+        @Schema(description = "응답대기(waitingCnt) / 응답완료(completedCnt) 개수")
+        private TalkBoxInfoDto talkBoxCntInfo;
+
+        @Schema(description = "해당 상품에 새로 들어온 질문 총개수", example = "5")
+        private Integer newCnt;
     }
 }

--- a/src/main/java/com/influy/domain/item/dto/ItemResponseDto.java
+++ b/src/main/java/com/influy/domain/item/dto/ItemResponseDto.java
@@ -185,4 +185,28 @@ public class ItemResponseDto {
         @Schema(description = "해당 톡박스 상태 [INITIAL, OPENED, CLOSED]", example = "OPENED")
         private TalkBoxOpenStatus status;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ViewTalkBoxCommentDto {
+        @Schema(description = "셀러 id", example = "1")
+        private Long sellerId;
+
+        @Schema(description = "셀러 프로필사진", example = "https://...")
+        private String sellerProfileImg;
+
+        @Schema(description = "셀러 아이디", example = "xoyeon")
+        private String sellerUsername;
+
+        @Schema(description = "셀러 닉네임", example = "소현")
+        private String sellerNickname;
+
+        @Schema(description = "생성일", example = "021-01-01T00:00")
+        private LocalDateTime createdAt;
+
+        @Schema(description = "톡박스 기본 멘트", example = "울랄라 먐마먀")
+        private String talkBoxComment;
+    }
 }

--- a/src/main/java/com/influy/domain/item/dto/ItemResponseDto.java
+++ b/src/main/java/com/influy/domain/item/dto/ItemResponseDto.java
@@ -172,4 +172,16 @@ public class ItemResponseDto {
         @Schema(description = "해당 아이템 톡박스 오픈 여부", example = "OPEN")
         private TalkBoxOpenStatus talkBoxOpenStatus;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TalkBoxOpenStatusDto {
+        @Schema(description = "아이템 id", example = "1")
+        private Long itemId;
+
+        @Schema(description = "해당 톡박스 상태 [INITIAL, OPENED, CLOSED]", example = "OPENED")
+        private TalkBoxOpenStatus status;
+    }
 }

--- a/src/main/java/com/influy/domain/item/dto/ItemResponseDto.java
+++ b/src/main/java/com/influy/domain/item/dto/ItemResponseDto.java
@@ -7,7 +7,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
 import java.time.LocalDateTime;
 import java.util.List;

--- a/src/main/java/com/influy/domain/item/dto/ItemResponseDto.java
+++ b/src/main/java/com/influy/domain/item/dto/ItemResponseDto.java
@@ -7,6 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
 import java.time.LocalDateTime;
 import java.util.List;

--- a/src/main/java/com/influy/domain/item/dto/jpql/TalkBoxInfoPairDto.java
+++ b/src/main/java/com/influy/domain/item/dto/jpql/TalkBoxInfoPairDto.java
@@ -1,0 +1,20 @@
+package com.influy.domain.item.dto.jpql;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+
+@Getter
+@AllArgsConstructor
+public class TalkBoxInfoPairDto {
+    @Schema(description = "아이템 id", example = "1")
+    private Long itemId;
+
+    @Schema(description = "답변 여부", example = "false")
+    private Boolean isAnswered;
+
+    @Schema(description = "해당 개수 (waiting / completed)", example = "5")
+    private Long cnt;
+
+}

--- a/src/main/java/com/influy/domain/item/entity/Item.java
+++ b/src/main/java/com/influy/domain/item/entity/Item.java
@@ -9,6 +9,7 @@ import com.influy.domain.question.entity.Question;
 import com.influy.domain.questionCategory.entity.QuestionCategory;
 import com.influy.domain.sellerProfile.entity.SellerProfile;
 import com.influy.global.common.BaseEntity;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -64,6 +65,9 @@ public class Item extends BaseEntity {
     private String marketLink;
 
     private String comment;
+
+    @Builder.Default
+    private String talkBoxComment = "";
 
     @Builder.Default
     private Boolean isArchived = false; //보관 여부

--- a/src/main/java/com/influy/domain/item/entity/TalkBoxInfoPair.java
+++ b/src/main/java/com/influy/domain/item/entity/TalkBoxInfoPair.java
@@ -1,0 +1,6 @@
+package com.influy.domain.item.entity;
+
+import java.util.Map;
+
+public record TalkBoxInfoPair(Map<Long, Integer> waitingCntMap, Map<Long, Integer> completedCntMap) {
+}

--- a/src/main/java/com/influy/domain/item/repository/ItemRepository.java
+++ b/src/main/java/com/influy/domain/item/repository/ItemRepository.java
@@ -24,4 +24,6 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
             "FROM Item p WHERE p.seller.id = :sellerId GROUP BY p.isArchived")
     List<ItemJPQLResponse> countBySellerIdGroupByIsArchived(@Param("sellerId") Long sellerId);
 
+    @Query("SELECT i FROM Item i WHERE i.seller.id = :sellerId AND i.talkBoxOpenStatus = 'OPENED'")
+    List<Item> findAllBySellerIdAndTalkBoxOpenStatus(Long sellerId);
 }

--- a/src/main/java/com/influy/domain/item/repository/ItemRepository.java
+++ b/src/main/java/com/influy/domain/item/repository/ItemRepository.java
@@ -18,12 +18,12 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
     Page<Item> findBySellerIdAndIsArchivedFalse(Long sellerId, Pageable pageable);
 
     @Query("SELECT i FROM Item i WHERE i.seller.id = :sellerId AND i.isArchived = false AND i.endDate > :now")
-    Page<Item> findOngoingItems(Long sellerId, LocalDateTime now, Pageable pageable);
+    Page<Item> findOngoingItems(@Param("sellerId")Long sellerId, @Param("now")LocalDateTime now, Pageable pageable);
 
     @Query("SELECT new com.influy.domain.item.dto.jpql.ItemJPQLResponse(p.isArchived, COUNT(p)) " +
             "FROM Item p WHERE p.seller.id = :sellerId GROUP BY p.isArchived")
     List<ItemJPQLResponse> countBySellerIdGroupByIsArchived(@Param("sellerId") Long sellerId);
 
     @Query("SELECT i FROM Item i WHERE i.seller.id = :sellerId AND i.talkBoxOpenStatus = 'OPENED'")
-    List<Item> findAllBySellerIdAndTalkBoxOpenStatus(Long sellerId);
+    List<Item> findAllBySellerIdAndTalkBoxOpenStatus(@Param("sellerId")Long sellerId);
 }

--- a/src/main/java/com/influy/domain/item/service/ItemService.java
+++ b/src/main/java/com/influy/domain/item/service/ItemService.java
@@ -5,6 +5,7 @@ import com.influy.domain.faqCard.dto.FaqCardResponseDto;
 import com.influy.domain.item.dto.ItemRequestDto;
 import com.influy.domain.item.dto.ItemResponseDto;
 import com.influy.domain.item.entity.Item;
+import com.influy.domain.item.entity.TalkBoxInfoPair;
 import com.influy.domain.item.entity.TalkBoxOpenStatus;
 import com.influy.domain.sellerProfile.entity.ItemSortType;
 import com.influy.global.apiPayload.code.status.SuccessStatus;
@@ -13,6 +14,7 @@ import com.influy.global.jwt.CustomUserDetails;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ItemService {
@@ -23,10 +25,12 @@ public interface ItemService {
     Item setAccess(CustomUserDetails userDetails, Long itemId, ItemRequestDto.AccessDto request);
     Item setStatus(CustomUserDetails userDetails, Long itemId, ItemRequestDto.StatusDto request);
     Integer getCount(Long sellerId, Boolean isArchived);
-    ItemResponseDto.DetailPreviewPageDto getDetailPreviewPage(Long sellerId, Boolean isArchived, PageRequestDto pageRequest, ItemSortType sortType, Boolean isOnGoing, Long memberId);
+    ItemResponseDto.DetailPreviewPageDto getDetailPreviewPage(CustomUserDetails userDetails, Long sellerId, Boolean isArchived, PageRequestDto pageRequest, ItemSortType sortType, Boolean isOnGoing);
     ItemResponseDto.ItemOverviewDto getItemOverview(Long sellerId, Long itemId);
     ItemResponseDto.TalkBoxOpenStatusDto changeOpenStatus(CustomUserDetails userDetails, Long itemId, TalkBoxOpenStatus openStatus);
     ItemResponseDto.ResultDto updateTalkBoxComment(CustomUserDetails userDetails, Long itemId, ItemRequestDto.TalkBoxCommentDto request);
     ItemResponseDto.ViewTalkBoxCommentDto getTalkBoxComment(CustomUserDetails userDetails, Long itemId);
+    ItemResponseDto.TalkBoxOpenedListDto getTalkBoxOpened(CustomUserDetails userDetails);
+    TalkBoxInfoPair getTalkBoxInfoPair(List<Item> itemList);
     Item findById(Long itemId);
 }

--- a/src/main/java/com/influy/domain/item/service/ItemService.java
+++ b/src/main/java/com/influy/domain/item/service/ItemService.java
@@ -27,5 +27,6 @@ public interface ItemService {
     ItemResponseDto.ItemOverviewDto getItemOverview(Long sellerId, Long itemId);
     ItemResponseDto.TalkBoxOpenStatusDto changeOpenStatus(CustomUserDetails userDetails, Long itemId, TalkBoxOpenStatus openStatus);
     ItemResponseDto.ResultDto updateTalkBoxComment(CustomUserDetails userDetails, Long itemId, ItemRequestDto.TalkBoxCommentDto request);
+    ItemResponseDto.ViewTalkBoxCommentDto getTalkBoxComment(CustomUserDetails userDetails, Long itemId);
     Item findById(Long itemId);
 }

--- a/src/main/java/com/influy/domain/item/service/ItemService.java
+++ b/src/main/java/com/influy/domain/item/service/ItemService.java
@@ -7,8 +7,10 @@ import com.influy.domain.item.dto.ItemResponseDto;
 import com.influy.domain.item.entity.Item;
 import com.influy.domain.item.entity.TalkBoxOpenStatus;
 import com.influy.domain.sellerProfile.entity.ItemSortType;
+import com.influy.global.apiPayload.code.status.SuccessStatus;
 import com.influy.global.common.PageRequestDto;
 import com.influy.global.jwt.CustomUserDetails;
+import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 
 import java.util.Optional;
@@ -24,6 +26,6 @@ public interface ItemService {
     ItemResponseDto.DetailPreviewPageDto getDetailPreviewPage(Long sellerId, Boolean isArchived, PageRequestDto pageRequest, ItemSortType sortType, Boolean isOnGoing, Long memberId);
     ItemResponseDto.ItemOverviewDto getItemOverview(Long sellerId, Long itemId);
     ItemResponseDto.TalkBoxOpenStatusDto changeOpenStatus(CustomUserDetails userDetails, Long itemId, TalkBoxOpenStatus openStatus);
-
+    ItemResponseDto.ResultDto updateTalkBoxComment(CustomUserDetails userDetails, Long itemId, ItemRequestDto.TalkBoxCommentDto request);
     Item findById(Long itemId);
 }

--- a/src/main/java/com/influy/domain/item/service/ItemService.java
+++ b/src/main/java/com/influy/domain/item/service/ItemService.java
@@ -1,9 +1,11 @@
 package com.influy.domain.item.service;
 
+import com.influy.domain.answer.dto.AnswerResponseDto;
 import com.influy.domain.faqCard.dto.FaqCardResponseDto;
 import com.influy.domain.item.dto.ItemRequestDto;
 import com.influy.domain.item.dto.ItemResponseDto;
 import com.influy.domain.item.entity.Item;
+import com.influy.domain.item.entity.TalkBoxOpenStatus;
 import com.influy.domain.sellerProfile.entity.ItemSortType;
 import com.influy.global.common.PageRequestDto;
 import com.influy.global.jwt.CustomUserDetails;
@@ -21,6 +23,7 @@ public interface ItemService {
     Integer getCount(Long sellerId, Boolean isArchived);
     ItemResponseDto.DetailPreviewPageDto getDetailPreviewPage(Long sellerId, Boolean isArchived, PageRequestDto pageRequest, ItemSortType sortType, Boolean isOnGoing, Long memberId);
     ItemResponseDto.ItemOverviewDto getItemOverview(Long sellerId, Long itemId);
+    ItemResponseDto.TalkBoxOpenStatusDto changeOpenStatus(CustomUserDetails userDetails, Long itemId, TalkBoxOpenStatus openStatus);
 
     Item findById(Long itemId);
 }

--- a/src/main/java/com/influy/domain/item/service/ItemServiceImpl.java
+++ b/src/main/java/com/influy/domain/item/service/ItemServiceImpl.java
@@ -36,6 +36,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 @Service
@@ -249,6 +250,17 @@ public class ItemServiceImpl implements ItemService {
         item.setTalkBoxOpenStatus(openStatus);
 
         return ItemConverter.toTalkBoxOpenStatusDto(itemId, openStatus);
+    }
+
+    @Override
+    @Transactional
+    public ItemResponseDto.ResultDto updateTalkBoxComment(CustomUserDetails userDetails, Long itemId, ItemRequestDto.TalkBoxCommentDto request) {
+        memberService.checkSeller(userDetails);
+        Item item = itemRepository.findById(itemId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.ITEM_NOT_FOUND));
+
+        item.setTalkBoxComment(request.getTalkBoxComment());
+        return ItemConverter.toResultDto(itemId);
     }
 
     @Override

--- a/src/main/java/com/influy/domain/item/service/ItemServiceImpl.java
+++ b/src/main/java/com/influy/domain/item/service/ItemServiceImpl.java
@@ -264,6 +264,14 @@ public class ItemServiceImpl implements ItemService {
     }
 
     @Override
+    public ItemResponseDto.ViewTalkBoxCommentDto getTalkBoxComment(CustomUserDetails userDetails, Long itemId) {
+        SellerProfile seller = memberService.checkSeller(userDetails);
+        Item item = itemRepository.findById(itemId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.ITEM_NOT_FOUND));
+        return ItemConverter.toViewTalkBoxCommentDto(seller, item);
+    }
+
+    @Override
     public Item findById(Long itemId) {
 
         return itemRepository.findById(itemId).orElseThrow(() -> new GeneralException(ErrorStatus.ITEM_NOT_FOUND));

--- a/src/main/java/com/influy/domain/item/service/ItemServiceImpl.java
+++ b/src/main/java/com/influy/domain/item/service/ItemServiceImpl.java
@@ -1,5 +1,7 @@
 package com.influy.domain.item.service;
 
+import com.influy.domain.answer.converter.AnswerConverter;
+import com.influy.domain.answer.dto.AnswerResponseDto;
 import com.influy.domain.category.entity.Category;
 import com.influy.domain.category.repository.CategoryRepository;
 import com.influy.domain.faqCard.converter.FaqCardConverter;
@@ -10,6 +12,7 @@ import com.influy.domain.item.converter.ItemConverter;
 import com.influy.domain.item.dto.ItemRequestDto;
 import com.influy.domain.item.dto.ItemResponseDto;
 import com.influy.domain.item.entity.Item;
+import com.influy.domain.item.entity.TalkBoxOpenStatus;
 import com.influy.domain.item.repository.ItemRepository;
 import com.influy.domain.itemCategory.converter.ItemCategoryConverter;
 import com.influy.domain.itemCategory.entity.ItemCategory;
@@ -233,6 +236,19 @@ public class ItemServiceImpl implements ItemService {
                 .orElseThrow(() -> new GeneralException(ErrorStatus.ITEM_NOT_FOUND));
 
         return ItemConverter.toItemOverviewDto(item);
+    }
+
+    @Override
+    @Transactional
+    public ItemResponseDto.TalkBoxOpenStatusDto changeOpenStatus(CustomUserDetails userDetails, Long itemId, TalkBoxOpenStatus openStatus) {
+        memberService.checkSeller(userDetails);
+        Item item = itemRepository.findById(itemId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.ITEM_NOT_FOUND));
+
+        if (openStatus == TalkBoxOpenStatus.INITIAL) throw new GeneralException((ErrorStatus.INVALID_TALKBOX_REQUEST));
+        item.setTalkBoxOpenStatus(openStatus);
+
+        return ItemConverter.toTalkBoxOpenStatusDto(itemId, openStatus);
     }
 
     @Override

--- a/src/main/java/com/influy/domain/like/controller/LikeRestController.java
+++ b/src/main/java/com/influy/domain/like/controller/LikeRestController.java
@@ -25,8 +25,8 @@ public class LikeRestController {
     @PostMapping("seller/{sellerId}/likes")
     @Operation(summary = "멤버가 셀러에 찜 추가")
     public ApiResponse<LikeResponseDto.SellerLikeDto> addSellerLike(@PathVariable("sellerId") Long sellerId,
-                                                                    @RequestParam(value="memberId", defaultValue = "1") Long memberId) {
-        Like like = likeService.toAddSellerLike(sellerId, memberId);
+                                                                    @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Like like = likeService.toAddSellerLike(sellerId, userDetails.getId());
         return ApiResponse.onSuccess(LikeConverter.toSellerLikeDto(like));
     }
 
@@ -34,16 +34,16 @@ public class LikeRestController {
     @Operation(summary = "멤버가 아이템에 찜 추가")
     public ApiResponse<LikeResponseDto.ItemLikeDto> addItemLike(@PathVariable("sellerId") Long sellerId,
                                                                 @PathVariable("itemId") Long itemId,
-                                                                @RequestParam(value="memberId", defaultValue = "1") Long memberId) {
-        Like like = likeService.toAddItemLike(sellerId, itemId, memberId);
+                                                                @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Like like = likeService.toAddItemLike(sellerId, itemId, userDetails.getId());
         return ApiResponse.onSuccess(LikeConverter.toItemLikeDto(like));
     }
 
     @PatchMapping("seller/{sellerId}/dislikes")
     @Operation(summary = "멤버가 셀러 찜 취소")
     public ApiResponse<LikeResponseDto.SellerLikeDto> cancelSellerLike(@PathVariable("sellerId") Long sellerId,
-                                                                       @RequestParam(value="memberId", defaultValue = "1") Long memberId) {
-        Like like = likeService.toCancelSellerLike(sellerId, memberId);
+                                                                       @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Like like = likeService.toCancelSellerLike(sellerId, userDetails.getId());
         return ApiResponse.onSuccess(LikeConverter.toSellerLikeDto(like));
     }
 
@@ -52,8 +52,8 @@ public class LikeRestController {
     @Operation(summary = "멤버가 아이템 찜 취소")
     public ApiResponse<LikeResponseDto.ItemLikeDto> cancelItemLike(@PathVariable("sellerId") Long sellerId,
                                                                    @PathVariable("itemId") Long itemId,
-                                                                   @RequestParam(value="memberId", defaultValue = "1") Long memberId) {
-        Like like = likeService.toCancelItemLike(sellerId, itemId, memberId);
+                                                                   @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Like like = likeService.toCancelItemLike(sellerId, itemId, userDetails.getId());
         return ApiResponse.onSuccess(LikeConverter.toItemLikeDto(like));
     }
 
@@ -82,7 +82,6 @@ public class LikeRestController {
     @Operation(summary = "멤버의 아이템 찜 리스트 조회")
     public ApiResponse<LikeResponseDto.ItemLikePageDto> getItemLikePage(@AuthenticationPrincipal CustomUserDetails userDetails,
                                                                         @Valid @ParameterObject PageRequestDto pageRequest) {
-        Page<Like> likePage = likeService.toGetItemLikePage(userDetails.getId(), pageRequest);
-        return ApiResponse.onSuccess(LikeConverter.toItemLikePageDto(likePage));
+        return ApiResponse.onSuccess(likeService.toGetItemLikePage(userDetails, pageRequest));
     }
 }

--- a/src/main/java/com/influy/domain/like/converter/LikeConverter.java
+++ b/src/main/java/com/influy/domain/like/converter/LikeConverter.java
@@ -2,6 +2,7 @@ package com.influy.domain.like.converter;
 
 import com.influy.domain.item.converter.ItemConverter;
 import com.influy.domain.item.entity.Item;
+import com.influy.domain.item.entity.TalkBoxInfoPair;
 import com.influy.domain.like.dto.LikeResponseDto;
 import com.influy.domain.like.entity.Like;
 import com.influy.domain.like.entity.LikeStatus;
@@ -70,10 +71,16 @@ public class LikeConverter {
                 .build();
     }
 
-    public static LikeResponseDto.ViewItemLikeDto toViewItemLikeDto(Like like) {
+    public static LikeResponseDto.ViewItemLikeDto toViewItemLikeDto(Like like, MemberRole memberRole, TalkBoxInfoPair talkBoxInfoPair) {
+        Item item = like.getItem();
         return LikeResponseDto.ViewItemLikeDto.builder()
                 .targetType(like.getTargetType())
-                .itemPreviewDto(like.getItem() != null ? ItemConverter.toDetailPreviewDto(like.getItem(), true, MemberRole.USER) : null)
+                .itemPreviewDto(item != null ? ItemConverter.toDetailPreviewDto(
+                item,
+                true,
+                memberRole,
+                talkBoxInfoPair.waitingCntMap().getOrDefault(item.getId(), 0),
+                talkBoxInfoPair.completedCntMap().getOrDefault(item.getId(), 0)) : null)
                 .build();
     }
 
@@ -91,9 +98,9 @@ public class LikeConverter {
                 .build();
     }
 
-    public static LikeResponseDto.ItemLikePageDto toItemLikePageDto(Page<Like> likePage) {
+    public static LikeResponseDto.ItemLikePageDto toItemLikePageDto(Page<Like> likePage, MemberRole memberRole, TalkBoxInfoPair talkBoxInfoPair) {
         List<LikeResponseDto.ViewItemLikeDto> viewLikeList = likePage.stream()
-                .map(LikeConverter::toViewItemLikeDto).toList();
+                .map(like -> toViewItemLikeDto(like, memberRole, talkBoxInfoPair)).toList();
 
         return LikeResponseDto.ItemLikePageDto.builder()
                 .itemLikeList(viewLikeList)

--- a/src/main/java/com/influy/domain/like/service/LikeService.java
+++ b/src/main/java/com/influy/domain/like/service/LikeService.java
@@ -3,6 +3,7 @@ package com.influy.domain.like.service;
 import com.influy.domain.like.dto.LikeResponseDto;
 import com.influy.domain.like.entity.Like;
 import com.influy.global.common.PageRequestDto;
+import com.influy.global.jwt.CustomUserDetails;
 import org.springframework.data.domain.Page;
 
 public interface LikeService {
@@ -13,5 +14,5 @@ public interface LikeService {
     LikeResponseDto.LikeCountDto toCountSellerLikes(Long sellerId);
     LikeResponseDto.LikeCountDto toCountItemLikes(Long sellerId, Long itemId);
     Page<Like> toGetSellerLikePage(Long memberId, PageRequestDto pageRequest);
-    Page<Like> toGetItemLikePage(Long memberId, PageRequestDto pageRequest);
+    LikeResponseDto.ItemLikePageDto toGetItemLikePage(CustomUserDetails userDetails, PageRequestDto pageRequest);
 }

--- a/src/main/java/com/influy/domain/question/controller/QuestionController.java
+++ b/src/main/java/com/influy/domain/question/controller/QuestionController.java
@@ -95,6 +95,4 @@ public class QuestionController {
 
         return ApiResponse.onSuccess(body);
     }
-
-//    @GetMapping("/seller/items/{itemId}/talkbox/")
 }

--- a/src/main/java/com/influy/domain/question/controller/QuestionController.java
+++ b/src/main/java/com/influy/domain/question/controller/QuestionController.java
@@ -83,4 +83,6 @@ public class QuestionController {
 
         return ApiResponse.onSuccess(body);
     }
+
+//    @GetMapping("/seller/items/{itemId}/talkbox/")
 }

--- a/src/main/java/com/influy/domain/question/controller/QuestionController.java
+++ b/src/main/java/com/influy/domain/question/controller/QuestionController.java
@@ -1,6 +1,8 @@
 package com.influy.domain.question.controller;
 
 
+import com.influy.domain.answer.dto.AnswerRequestDto;
+import com.influy.domain.answer.dto.AnswerResponseDto;
 import com.influy.domain.item.entity.Item;
 import com.influy.domain.item.service.ItemService;
 import com.influy.domain.member.entity.Member;
@@ -17,11 +19,13 @@ import com.influy.domain.sellerProfile.entity.SellerProfile;
 import com.influy.domain.sellerProfile.service.SellerProfileService;
 import com.influy.global.apiPayload.ApiResponse;
 import com.influy.global.apiPayload.code.status.ErrorStatus;
+import com.influy.global.apiPayload.code.status.SuccessStatus;
 import com.influy.global.apiPayload.exception.GeneralException;
 import com.influy.global.jwt.CustomUserDetails;
 import com.influy.global.jwt.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
@@ -95,4 +99,24 @@ public class QuestionController {
 
         return ApiResponse.onSuccess(body);
     }
+
+    @GetMapping("/seller/items/{itemId}/talkbox/{questionCategoryId}/questions/{questionTagId}/{questionId}")
+    @Operation(summary = "셀러뷰 질문별 질문 조회", description = "해당 질문과 해당 질문에 대한 답변 리스트")
+    public ApiResponse<QuestionResponseDTO.QnAListDto> viewQnA(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                             @PathVariable("itemId") Long itemId,
+                                                             @PathVariable("questionCategoryId") Long questionCategoryId,
+                                                             @PathVariable("questionTagId") Long questionTagId,
+                                                             @PathVariable("questionId") Long questionId) {
+        return ApiResponse.onSuccess(questionService.viewQnA(userDetails, itemId, questionCategoryId, questionTagId, questionId));
+    }
+
+    @DeleteMapping("/seller/items/{itemId}/talkbox/{questionCategoryId}/questions")
+    @Operation(summary = "선택한 질문들 삭제 (여러개 가능, 질문 객체 삭제가 아닌 isHidden 처리)")
+    public ApiResponse<QuestionResponseDTO.DeleteResultDto> delete(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                                 @PathVariable("itemId") Long itemId,
+                                                                 @PathVariable("questionCategoryId") Long questionCategoryId,
+                                                                 @RequestBody @Valid QuestionRequestDTO.DeleteDto request) {
+        return ApiResponse.onSuccess(questionService.delete(userDetails, itemId, questionCategoryId, request));
+    }
+
 }

--- a/src/main/java/com/influy/domain/question/converter/QuestionConverter.java
+++ b/src/main/java/com/influy/domain/question/converter/QuestionConverter.java
@@ -1,14 +1,20 @@
 package com.influy.domain.question.converter;
 
+import com.influy.domain.answer.converter.AnswerConverter;
+import com.influy.domain.answer.dto.AnswerResponseDto;
+import com.influy.domain.answer.entity.Answer;
 import com.influy.domain.item.entity.Item;
 import com.influy.domain.member.entity.Member;
 import com.influy.domain.question.dto.QuestionResponseDTO;
 import com.influy.domain.question.entity.Question;
 import com.influy.domain.questionTag.entity.QuestionTag;
 import com.influy.domain.sellerProfile.entity.SellerProfile;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.springframework.data.domain.Page;
 
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Map;
 
 public class QuestionConverter {
@@ -57,6 +63,35 @@ public class QuestionConverter {
                 .totalElements(questions.getTotalElements())
                 .listSize(questions.getSize())
                 .questions(questions.map(question->QuestionConverter.toGeneralDTO(question, countMap.get(question.getMember().getId()))).getContent())
+                .build();
+    }
+
+    public static QuestionResponseDTO.QnAListDto toQnAListDto(Question question, List<Answer> answerList, Long nth) {
+        QuestionResponseDTO.QuestionViewDto questionDto = QuestionConverter.toQuestionViewDto(question, nth);
+        AnswerResponseDto.AnswerViewListDto answerListDto = AnswerConverter.toAnswerViewListDto(answerList);
+
+        return QuestionResponseDTO.QnAListDto.builder()
+                .questionDto(questionDto)
+                .answerListDto(answerListDto)
+                .build();
+    }
+
+    private static QuestionResponseDTO.QuestionViewDto toQuestionViewDto(Question question, Long nth) {
+        Member member = question.getMember();
+        return QuestionResponseDTO.QuestionViewDto.builder()
+                .questionId(question.getId())
+                .memberId(member.getId())
+                .username(member.getUsername())
+                .content(question.getContent())
+                .nthQuestion(nth)
+                .questionTime(question.getCreatedAt())
+                .questionTag(question.getQuestionTag().getName())
+                .build();
+    }
+
+    public static QuestionResponseDTO.DeleteResultDto toDeleteResultDto(List<Long> questionList) {
+        return QuestionResponseDTO.DeleteResultDto.builder()
+                .questionIdList(questionList)
                 .build();
     }
 }

--- a/src/main/java/com/influy/domain/question/dto/QuestionRequestDTO.java
+++ b/src/main/java/com/influy/domain/question/dto/QuestionRequestDTO.java
@@ -3,11 +3,19 @@ package com.influy.domain.question.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
+import java.util.List;
+
 public class QuestionRequestDTO {
 
     @Getter
     public static class Create{
         @Schema(description = "질문 내용", example = "폐업하시면 저는 옷 어디서 사나요?")
         private String content;
+    }
+
+    @Getter
+    public static class DeleteDto {
+        @Schema(description = "삭제할 질문 id 리스트 (1개도 가능)", example = "[1, 2]")
+        private List<Long> questionIdList;
     }
 }

--- a/src/main/java/com/influy/domain/question/dto/QuestionResponseDTO.java
+++ b/src/main/java/com/influy/domain/question/dto/QuestionResponseDTO.java
@@ -1,5 +1,6 @@
 package com.influy.domain.question.dto;
 
+import com.influy.domain.answer.dto.AnswerResponseDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -63,5 +64,53 @@ public class QuestionResponseDTO {
         private String categoryName;
         @Schema(description = "생성 일자", example = "2025-01-03Z13:13:13")
         private LocalDateTime createdAt;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class QuestionViewDto {
+        @Schema(description = "질문 아이디", example = "1")
+        private Long questionId;
+
+        @Schema(description = "질문한 회원 아이디", example = "2")
+        private Long memberId;
+
+        @Schema(description = "질문한 회원 유저네임", example = "@pullpullpull")
+        private String username;
+
+        @Schema(description = "내용", example = "더 싸게는 안되나요?")
+        private String content;
+
+        @Schema(description = "몇차 질문", example = "4")
+        private Long nthQuestion;
+
+        @Schema(description = "질문 시간", example = "2025-01-03Z13:13:13")
+        private LocalDateTime questionTime;
+
+        @Schema(description = "질문 태그 이름", example = "네이비")
+        private String questionTag;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class QnAListDto {
+        @Schema(description = "질문 뷰")
+        private QuestionViewDto questionDto;
+
+        @Schema(description = "답변 리스트 뷰")
+        private AnswerResponseDto.AnswerViewListDto answerListDto;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DeleteResultDto {
+        @Schema(description = "삭제된 질문 id 리스트")
+        private List<Long> questionIdList;
     }
 }

--- a/src/main/java/com/influy/domain/question/entity/Question.java
+++ b/src/main/java/com/influy/domain/question/entity/Question.java
@@ -46,6 +46,10 @@ public class Question extends BaseEntity {
     private Boolean isAnswered=false;
 
     @Builder.Default
+    @Setter
+    private Boolean isChecked=false;
+
+    @Builder.Default
     private Integer itemPeriod=1;
 
     @Setter

--- a/src/main/java/com/influy/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/com/influy/domain/question/repository/QuestionRepository.java
@@ -46,7 +46,7 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
     WHERE qt.questionCategory = :questionCategory
     AND q.isAnswered = :isAnswered
     """)
-    Page<Question> findAllByQuestionCategoryAndIsAnswered(QuestionCategory questionCategory, Boolean isAnswered, Pageable pageable);
+    Page<Question> findAllByQuestionCategoryAndIsAnswered(@Param("questionCategory")QuestionCategory questionCategory, @Param("isAnswered")Boolean isAnswered, Pageable pageable);
 
     @Query("""
         SELECT q FROM Question q
@@ -55,7 +55,7 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
           AND q.questionTag.questionCategory.id = :questionCategoryId
           AND q.questionTag.questionCategory.item.id = :itemId
     """)
-    Optional<Question> findValidQuestion(Long itemId, Long questionCategoryId, Long questionTagId, Long questionId);
+    Optional<Question> findValidQuestion(@Param("itemId")Long itemId, @Param("questionCategoryId")Long questionCategoryId, @Param("questionTagId")Long questionTagId, @Param("questionId")Long questionId);
 
     Integer countQuestionsByItemIdAndIsChecked(Long id, Boolean b);
 
@@ -65,5 +65,5 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
         WHERE q.item.id IN :itemIdList
         GROUP BY q.item.id, q.isAnswered
     """)
-    List<TalkBoxInfoPairDto> countByItemIdAndIsAnswered(List<Long> itemIdList);
+    List<TalkBoxInfoPairDto> countByItemIdAndIsAnswered(@Param("itemIdList")List<Long> itemIdList);
 }

--- a/src/main/java/com/influy/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/com/influy/domain/question/repository/QuestionRepository.java
@@ -1,5 +1,6 @@
 package com.influy.domain.question.repository;
 
+import com.influy.domain.item.dto.jpql.TalkBoxInfoPairDto;
 import com.influy.domain.member.entity.Member;
 import com.influy.domain.question.dto.jpql.JPQLResult;
 import com.influy.domain.question.entity.Question;
@@ -56,7 +57,13 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
     """)
     Optional<Question> findValidQuestion(Long itemId, Long questionCategoryId, Long questionTagId, Long questionId);
 
-    Integer countQuestionsByItemIdAndIsAnswered(Long id, Boolean b);
-
     Integer countQuestionsByItemIdAndIsChecked(Long id, Boolean b);
+
+    @Query("""
+        SELECT new com.influy.domain.item.dto.jpql.TalkBoxInfoPairDto(q.item.id, q.isAnswered, COUNT(q))
+        FROM Question q
+        WHERE q.item.id IN :itemIdList
+        GROUP BY q.item.id, q.isAnswered
+    """)
+    List<TalkBoxInfoPairDto> countByItemIdAndIsAnswered(List<Long> itemIdList);
 }

--- a/src/main/java/com/influy/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/com/influy/domain/question/repository/QuestionRepository.java
@@ -22,10 +22,9 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
 
     @Query("SELECT COUNT(q) AS cnt " +
             "FROM Question q " +
-            "JOIN q.item i " +
-            "JOIN i.seller s " +
-            "WHERE s = :seller AND q.member = :member " +
-            "GROUP BY q.member.id")
+            "LEFT JOIN q.item i " +
+            "LEFT JOIN i.seller s " +
+            "WHERE s = :seller AND q.member = :member ")
     Long countByMemberAndSeller(@Param("member") Member member, @Param("seller") SellerProfile seller);
 
     @Query("SELECT q.member.id AS memberId, COUNT(q) AS cnt " +

--- a/src/main/java/com/influy/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/com/influy/domain/question/repository/QuestionRepository.java
@@ -55,4 +55,8 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
           AND q.questionTag.questionCategory.item.id = :itemId
     """)
     Optional<Question> findValidQuestion(Long itemId, Long questionCategoryId, Long questionTagId, Long questionId);
+
+    Integer countQuestionsByItemIdAndIsAnswered(Long id, Boolean b);
+
+    Integer countQuestionsByItemIdAndIsChecked(Long id, Boolean b);
 }

--- a/src/main/java/com/influy/domain/question/service/QuestionService.java
+++ b/src/main/java/com/influy/domain/question/service/QuestionService.java
@@ -1,10 +1,16 @@
 package com.influy.domain.question.service;
 
+import com.influy.domain.answer.dto.AnswerRequestDto;
+import com.influy.domain.answer.dto.AnswerResponseDto;
 import com.influy.domain.item.entity.Item;
 import com.influy.domain.member.entity.Member;
+import com.influy.domain.question.dto.QuestionRequestDTO;
+import com.influy.domain.question.dto.QuestionResponseDTO;
 import com.influy.domain.question.entity.Question;
 import com.influy.domain.questionCategory.entity.QuestionCategory;
 import com.influy.domain.sellerProfile.entity.SellerProfile;
+import com.influy.global.apiPayload.code.status.SuccessStatus;
+import com.influy.global.jwt.CustomUserDetails;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -19,4 +25,8 @@ public interface QuestionService {
     Long getTimesMemberAskedSeller(Member member, SellerProfile seller);
 
     Map<Long, Long> getNthQuestionMap(SellerProfile seller, Page<Question> questions);
+
+    QuestionResponseDTO.QnAListDto viewQnA(CustomUserDetails userDetails, Long itemId, Long questionCategoryId, Long questionTagId, Long questionId);
+
+    QuestionResponseDTO.DeleteResultDto delete(CustomUserDetails userDetails, Long itemId, Long questionCategoryId, QuestionRequestDTO.DeleteDto request);
 }

--- a/src/main/java/com/influy/domain/question/service/QuestionServiceImpl.java
+++ b/src/main/java/com/influy/domain/question/service/QuestionServiceImpl.java
@@ -1,9 +1,16 @@
 package com.influy.domain.question.service;
 
 import com.influy.domain.ai.service.AiService;
+import com.influy.domain.answer.converter.AnswerConverter;
+import com.influy.domain.answer.dto.AnswerRequestDto;
+import com.influy.domain.answer.dto.AnswerResponseDto;
+import com.influy.domain.answer.entity.Answer;
 import com.influy.domain.item.entity.Item;
 import com.influy.domain.member.entity.Member;
+import com.influy.domain.member.service.MemberService;
 import com.influy.domain.question.converter.QuestionConverter;
+import com.influy.domain.question.dto.QuestionRequestDTO;
+import com.influy.domain.question.dto.QuestionResponseDTO;
 import com.influy.domain.question.dto.jpql.JPQLResult;
 import com.influy.domain.question.entity.Question;
 import com.influy.domain.question.repository.QuestionRepository;
@@ -14,6 +21,7 @@ import com.influy.domain.questionTag.repository.QuestionTagRepository;
 import com.influy.domain.sellerProfile.entity.SellerProfile;
 import com.influy.global.apiPayload.code.status.ErrorStatus;
 import com.influy.global.apiPayload.exception.GeneralException;
+import com.influy.global.jwt.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -32,6 +40,7 @@ public class QuestionServiceImpl implements QuestionService {
     private final QuestionCategoryRepository questionCategoryRepository;
     private final QuestionTagRepository questionTagRepository;
     private final AiService aiService;
+    private final MemberService memberService;
 
 
     @Override
@@ -73,5 +82,28 @@ public class QuestionServiceImpl implements QuestionService {
                 .collect(Collectors.toMap(JPQLResult.MemberQuestionCount::getMemberId, JPQLResult.MemberQuestionCount::getCnt));
     }
 
+    @Override
+    public QuestionResponseDTO.QnAListDto viewQnA(CustomUserDetails userDetails, Long itemId, Long questionCategoryId, Long questionTagId, Long questionId) {
+        SellerProfile seller = memberService.checkSeller(userDetails);
+        Question question = questionRepository.findValidQuestion(itemId, questionCategoryId, questionTagId, questionId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.QUESTION_INVALID_RELATION));
+        Long nth = questionRepository.countByMemberAndSeller(userDetails.getMember(), seller);
+        List<Answer> answerList = question.getAnswerList();
 
+        return QuestionConverter.toQnAListDto(question, answerList, nth);
+    }
+
+    @Override
+    @Transactional
+    public QuestionResponseDTO.DeleteResultDto delete(CustomUserDetails userDetails, Long itemId, Long questionCategoryId, QuestionRequestDTO.DeleteDto request) {
+        memberService.checkSeller(userDetails);
+
+        // 질문을 삭제하면 해당 질문의 모든 답변들도 삭제된다고 가정 (셀러 입장)
+        List<Question> questionList= questionRepository.findAllById(request.getQuestionIdList());
+        for (Question question : questionList) {
+            question.setIsHidden(true);
+        }
+
+        return QuestionConverter.toDeleteResultDto(request.getQuestionIdList());
+    }
 }

--- a/src/main/java/com/influy/domain/questionCategory/controller/QuestionCategoryController.java
+++ b/src/main/java/com/influy/domain/questionCategory/controller/QuestionCategoryController.java
@@ -40,24 +40,6 @@ public class QuestionCategoryController {
         return ApiResponse.onSuccess(QuestionCategoryConverter.toViewListDto(questionCategoryList));
     }
 
-    @PatchMapping("seller/items/{itemId}/question-categories")
-    @Operation(summary = "질문 카테고리 수정 (한번에 하나, 추가 api 한번 이상 호출한 이후에만 사용)")
-    public ApiResponse<QuestionCategoryResponseDto.ViewDto> update(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                                                     @PathVariable("itemId") Long itemId,
-                                                                     @RequestBody QuestionCategoryRequestDto.UpdateDto request) {
-        QuestionCategory questionCategory = questionCategoryService.update(userDetails, itemId, request);
-        return ApiResponse.onSuccess(QuestionCategoryConverter.toViewDto(questionCategory));
-    }
-
-    @DeleteMapping("seller/items/{itemId}/question-categories")
-    @Operation(summary = "질문 카테고리 삭제 (한번에 하나, 추가 api 한번 이상 호출한 이후에만 사용)")
-    public ApiResponse<QuestionCategoryResponseDto.DeleteResultDto> delete(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                                                           @PathVariable("itemId") Long itemId,
-                                                                           @RequestBody QuestionCategoryRequestDto.DeleteDto request) {
-        questionCategoryService.delete(userDetails, itemId, request);
-        return ApiResponse.onSuccess(QuestionCategoryConverter.toDeleteResultDto(request.getId()));
-    }
-
     @GetMapping("seller/{sellerId}/items/{itemId}/question-categories")
     @Operation(summary = "질문 카테고리 리스트 조회 (질문 많은 순)", description = "미확인인 질문 개수는 질문 파트 개발 이후 수정할 예정입니다.")
     public ApiResponse<QuestionCategoryResponseDto.ListWithCntDto> getList(@PathVariable("sellerId") Long sellerId,

--- a/src/main/java/com/influy/domain/questionCategory/controller/QuestionCategoryController.java
+++ b/src/main/java/com/influy/domain/questionCategory/controller/QuestionCategoryController.java
@@ -41,7 +41,7 @@ public class QuestionCategoryController {
     }
 
     @PatchMapping("seller/items/{itemId}/question-categories")
-    @Operation(summary = "질문 카테고리 수정 (한번에 하나)")
+    @Operation(summary = "질문 카테고리 수정 (한번에 하나, 추가 api 한번 이상 호출한 이후에만 사용)")
     public ApiResponse<QuestionCategoryResponseDto.ViewDto> update(@AuthenticationPrincipal CustomUserDetails userDetails,
                                                                      @PathVariable("itemId") Long itemId,
                                                                      @RequestBody QuestionCategoryRequestDto.UpdateDto request) {
@@ -50,7 +50,7 @@ public class QuestionCategoryController {
     }
 
     @DeleteMapping("seller/items/{itemId}/question-categories")
-    @Operation(summary = "질문 카테고리 삭제 (한번에 하나)")
+    @Operation(summary = "질문 카테고리 삭제 (한번에 하나, 추가 api 한번 이상 호출한 이후에만 사용)")
     public ApiResponse<QuestionCategoryResponseDto.DeleteResultDto> delete(@AuthenticationPrincipal CustomUserDetails userDetails,
                                                                            @PathVariable("itemId") Long itemId,
                                                                            @RequestBody QuestionCategoryRequestDto.DeleteDto request) {

--- a/src/main/java/com/influy/domain/questionCategory/controller/QuestionCategoryController.java
+++ b/src/main/java/com/influy/domain/questionCategory/controller/QuestionCategoryController.java
@@ -25,19 +25,19 @@ public class QuestionCategoryController {
 
     @PostMapping("seller/items/{itemId}/question-categories/generate")
     @Operation(summary = "질문 카테고리 (대분류) ai 생성")
-    public ApiResponse<QuestionCategoryResponseDto.GenerateResultDto> generateCategory(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                                                                       @PathVariable("itemId") Long itemId) {
-        List<QuestionCategory> questionCategoryList = questionCategoryService.generateCategory(userDetails, itemId);
-        return ApiResponse.onSuccess(QuestionCategoryConverter.toGenerateResultDto(questionCategoryList));
+    public ApiResponse<QuestionCategoryResponseDto.GeneratedResultDto> generateCategory(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                                                 @PathVariable("itemId") Long itemId) {
+        List<String> questionCategoryList = questionCategoryService.generateCategory(userDetails, itemId);
+        return ApiResponse.onSuccess(QuestionCategoryConverter.toGeneratedResultDto(questionCategoryList));
     }
 
     @PostMapping("seller/items/{itemId}/question-categories")
-    @Operation(summary = "질문 카테고리 추가 (한번에 하나)")
-    public ApiResponse<QuestionCategoryResponseDto.ViewDto> add(@AuthenticationPrincipal CustomUserDetails userDetails,
+    @Operation(summary = "질문 카테고리 추가 (한번에 여러개)")
+    public ApiResponse<QuestionCategoryResponseDto.ViewListDto> addAll(@AuthenticationPrincipal CustomUserDetails userDetails,
                                                                      @PathVariable("itemId") Long itemId,
-                                                                @RequestBody QuestionCategoryRequestDto.AddDto request) {
-        QuestionCategory questionCategory = questionCategoryService.add(userDetails, itemId, request);
-        return ApiResponse.onSuccess(QuestionCategoryConverter.toViewDto(questionCategory));
+                                                                @RequestBody QuestionCategoryRequestDto.AddListDto request) {
+        List<QuestionCategory> questionCategoryList = questionCategoryService.addAll(userDetails, itemId, request);
+        return ApiResponse.onSuccess(QuestionCategoryConverter.toViewListDto(questionCategoryList));
     }
 
     @PatchMapping("seller/items/{itemId}/question-categories")
@@ -60,8 +60,8 @@ public class QuestionCategoryController {
 
     @GetMapping("seller/{sellerId}/items/{itemId}/question-categories")
     @Operation(summary = "질문 카테고리 리스트 조회 (질문 많은 순)", description = "미확인인 질문 개수는 질문 파트 개발 이후 수정할 예정입니다.")
-    public ApiResponse<QuestionCategoryResponseDto.ListDto> getList(@PathVariable("sellerId") Long sellerId,
-                                                                    @PathVariable("itemId") Long itemId) {
+    public ApiResponse<QuestionCategoryResponseDto.ListWithCntDto> getList(@PathVariable("sellerId") Long sellerId,
+                                                                           @PathVariable("itemId") Long itemId) {
         return ApiResponse.onSuccess(questionCategoryService.getList(sellerId, itemId));
     }
 }

--- a/src/main/java/com/influy/domain/questionCategory/converter/QuestionCategoryConverter.java
+++ b/src/main/java/com/influy/domain/questionCategory/converter/QuestionCategoryConverter.java
@@ -3,7 +3,6 @@ package com.influy.domain.questionCategory.converter;
 import com.influy.domain.item.entity.Item;
 import com.influy.domain.questionCategory.dto.QuestionCategoryResponseDto;
 import com.influy.domain.questionCategory.entity.QuestionCategory;
-import org.springframework.data.domain.Page;
 
 import java.util.List;
 import java.util.Map;
@@ -39,7 +38,7 @@ public class QuestionCategoryConverter {
                 .build();
     }
 
-    public static QuestionCategoryResponseDto.ListDto toListDto(List<QuestionCategory> questionCategoryList, Map<Long, Integer> questionCntMap, Map<Long, Integer> unCheckedCntMap) {
+    public static QuestionCategoryResponseDto.ListWithCntDto toListWithCntDto(List<QuestionCategory> questionCategoryList, Map<Long, Integer> questionCntMap, Map<Long, Integer> unCheckedCntMap) {
         List<QuestionCategoryResponseDto.ViewWithCntDto> qcList = questionCategoryList.stream()
                 .map(qc -> toViewWithCntDto(
                         qc,
@@ -48,20 +47,26 @@ public class QuestionCategoryConverter {
                 ))
                 .toList();
 
-        return QuestionCategoryResponseDto.ListDto.builder()
+        return QuestionCategoryResponseDto.ListWithCntDto.builder()
                 .viewList(qcList)
                 .listSize(qcList.size())
                 .build();
     }
 
 
-    public static QuestionCategoryResponseDto.GenerateResultDto toGenerateResultDto(List<QuestionCategory> questionCategoryList) {
+    public static QuestionCategoryResponseDto.ViewListDto toViewListDto(List<QuestionCategory> questionCategoryList) {
         List<QuestionCategoryResponseDto.ViewDto> viewList = questionCategoryList.stream()
                 .map(QuestionCategoryConverter::toViewDto)
                 .toList();
 
-        return QuestionCategoryResponseDto.GenerateResultDto.builder()
+        return QuestionCategoryResponseDto.ViewListDto.builder()
                 .viewList(viewList)
+                .build();
+    }
+
+    public static QuestionCategoryResponseDto.GeneratedResultDto toGeneratedResultDto(List<String> generatedCategoryList) {
+        return QuestionCategoryResponseDto.GeneratedResultDto.builder()
+                .generatedNameList(generatedCategoryList)
                 .build();
     }
 }

--- a/src/main/java/com/influy/domain/questionCategory/converter/QuestionCategoryConverter.java
+++ b/src/main/java/com/influy/domain/questionCategory/converter/QuestionCategoryConverter.java
@@ -23,12 +23,6 @@ public class QuestionCategoryConverter {
                 .build();
     }
 
-    public static QuestionCategoryResponseDto.DeleteResultDto toDeleteResultDto(Long id) {
-        return QuestionCategoryResponseDto.DeleteResultDto.builder()
-                .id(id)
-                .build();
-    }
-
     public static QuestionCategoryResponseDto.ViewWithCntDto toViewWithCntDto(QuestionCategory questionCategory, Integer questionCnt, Integer unCheckedCnt) {
         return QuestionCategoryResponseDto.ViewWithCntDto.builder()
                 .questionCategoryId(questionCategory.getId())

--- a/src/main/java/com/influy/domain/questionCategory/dto/QuestionCategoryRequestDto.java
+++ b/src/main/java/com/influy/domain/questionCategory/dto/QuestionCategoryRequestDto.java
@@ -11,19 +11,4 @@ public class QuestionCategoryRequestDto {
         @Schema(description = "추가할 질문 카테고리 이름 리스트", example = "[ 사이즈, 색상, 세탁 ]")
         private List<String> categoryList;
     }
-
-    @Getter
-    public static class UpdateDto{
-        @Schema(description = "카테고리 id", example = "1")
-        private Long id;
-
-        @Schema(description = "질문 카테고리 이름", example = "사이즈")
-        private String category;
-    }
-
-    @Getter
-    public static class DeleteDto{
-        @Schema(description = "카테고리 id", example = "1")
-        private Long id;
-    }
 }

--- a/src/main/java/com/influy/domain/questionCategory/dto/QuestionCategoryRequestDto.java
+++ b/src/main/java/com/influy/domain/questionCategory/dto/QuestionCategoryRequestDto.java
@@ -3,11 +3,13 @@ package com.influy.domain.questionCategory.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
+import java.util.List;
+
 public class QuestionCategoryRequestDto {
     @Getter
-    public static class AddDto{
-        @Schema(description = "질문 카테고리 이름", example = "사이즈")
-        private String category;
+    public static class AddListDto{
+        @Schema(description = "추가할 질문 카테고리 이름 리스트", example = "[ 사이즈, 색상, 세탁 ]")
+        private List<String> categoryList;
     }
 
     @Getter

--- a/src/main/java/com/influy/domain/questionCategory/dto/QuestionCategoryResponseDto.java
+++ b/src/main/java/com/influy/domain/questionCategory/dto/QuestionCategoryResponseDto.java
@@ -15,15 +15,6 @@ public class QuestionCategoryResponseDto {
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class DeleteResultDto {
-        @Schema(description = "질문 카테고리 id", example = "1")
-        private Long id;
-    }
-
-    @Getter
-    @Builder
-    @AllArgsConstructor
-    @NoArgsConstructor
     public static class ViewListDto {
         @Schema(description = "질문 카테고리 리스트", example = "[ 사이즈, 세탁, 색상 ]")
         private List<ViewDto> viewList;

--- a/src/main/java/com/influy/domain/questionCategory/dto/QuestionCategoryResponseDto.java
+++ b/src/main/java/com/influy/domain/questionCategory/dto/QuestionCategoryResponseDto.java
@@ -1,7 +1,6 @@
 package com.influy.domain.questionCategory.dto;
 
 import com.influy.domain.question.dto.QuestionResponseDTO;
-import com.influy.domain.questionCategory.entity.QuestionCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -25,8 +24,8 @@ public class QuestionCategoryResponseDto {
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class GenerateResultDto {
-        @Schema(description = "질문 카테고리 리스트")
+    public static class ViewListDto {
+        @Schema(description = "질문 카테고리 리스트", example = "[ 사이즈, 세탁, 색상 ]")
         private List<ViewDto> viewList;
     }
 
@@ -34,7 +33,7 @@ public class QuestionCategoryResponseDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class ListDto {
+    public static class ListWithCntDto {
         @Schema(description = "질문 카테고리 리스트")
         private List<ViewWithCntDto> viewList;
 
@@ -69,6 +68,15 @@ public class QuestionCategoryResponseDto {
 
         @Schema(description = "질문 카테고리", example = "사이즈")
         private String questionCategoryName;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class GeneratedResultDto {
+        @Schema(description = "생성된 질문 카테고리 리스트", example = "[ 사이즈, 세탁, 색상 ]")
+        private List<String> generatedNameList;
     }
 
     @Builder @Getter

--- a/src/main/java/com/influy/domain/questionCategory/repository/QuestionCategoryRepository.java
+++ b/src/main/java/com/influy/domain/questionCategory/repository/QuestionCategoryRepository.java
@@ -18,11 +18,11 @@ public interface QuestionCategoryRepository extends JpaRepository<QuestionCatego
     FROM QuestionCategory qc
     LEFT JOIN QuestionTag qt ON qt.questionCategory = qc
     LEFT JOIN Question q ON q.questionTag = qt
-    WHERE qc.item.id = :itemId
+    WHERE qc.item.id = :itemId AND qc.item.seller.id = :sellerId
     GROUP BY qc
     ORDER BY COUNT(q.id) DESC
     """)
-    List<QuestionCategory> findQuestionCategories(@Param("itemId") Long itemId);
+    List<QuestionCategory> findQuestionCategories(@Param("itemId") Long itemId, @Param("sellerId") Long sellerId);
 
     @Query("""
     SELECT COUNT(q)

--- a/src/main/java/com/influy/domain/questionCategory/repository/QuestionCategoryRepository.java
+++ b/src/main/java/com/influy/domain/questionCategory/repository/QuestionCategoryRepository.java
@@ -33,7 +33,5 @@ public interface QuestionCategoryRepository extends JpaRepository<QuestionCatego
     """)
     int countQuestionsByCategoryId(@Param("questionCategoryId") Long questionCategoryId);
 
-    List<QuestionCategory> findAllByItem(Item item);
-
     Optional<QuestionCategory> findByIdAndItemId(Long questionCategoryId, Long itemId);
 }

--- a/src/main/java/com/influy/domain/questionCategory/service/QuestionCategoryService.java
+++ b/src/main/java/com/influy/domain/questionCategory/service/QuestionCategoryService.java
@@ -10,8 +10,6 @@ import java.util.List;
 
 public interface QuestionCategoryService {
     List<QuestionCategory> addAll(CustomUserDetails userDetails, Long itemId, QuestionCategoryRequestDto.AddListDto request);
-    QuestionCategory update(CustomUserDetails userDetails, Long itemId, QuestionCategoryRequestDto.UpdateDto request);
-    void delete(CustomUserDetails userDetails, Long itemId, QuestionCategoryRequestDto.DeleteDto request);
     QuestionCategoryResponseDto.ListWithCntDto getList(Long sellerId, Long itemId);
     List<String> generateCategory(CustomUserDetails userDetails, Long itemId);
     QuestionCategory findByCategoryIdAndItemId(Long questionCategoryId, Long itemId);

--- a/src/main/java/com/influy/domain/questionCategory/service/QuestionCategoryService.java
+++ b/src/main/java/com/influy/domain/questionCategory/service/QuestionCategoryService.java
@@ -9,9 +9,9 @@ import java.util.List;
 
 
 public interface QuestionCategoryService {
-    QuestionCategory add(CustomUserDetails userDetails, Long itemId, QuestionCategoryRequestDto.AddDto request);
+    List<QuestionCategory> addAll(CustomUserDetails userDetails, Long itemId, QuestionCategoryRequestDto.AddListDto request);
     QuestionCategory update(CustomUserDetails userDetails, Long itemId, QuestionCategoryRequestDto.UpdateDto request);
     void delete(CustomUserDetails userDetails, Long itemId, QuestionCategoryRequestDto.DeleteDto request);
-    QuestionCategoryResponseDto.ListDto getList(Long sellerId, Long itemId);
-    List<QuestionCategory> generateCategory(CustomUserDetails userDetails, Long itemId);
+    QuestionCategoryResponseDto.ListWithCntDto getList(Long sellerId, Long itemId);
+    List<String> generateCategory(CustomUserDetails userDetails, Long itemId);
 }

--- a/src/main/java/com/influy/domain/questionCategory/service/QuestionCategoryServiceImpl.java
+++ b/src/main/java/com/influy/domain/questionCategory/service/QuestionCategoryServiceImpl.java
@@ -58,38 +58,6 @@ public class QuestionCategoryServiceImpl implements QuestionCategoryService{
         return questionCategoryList;
     }
 
-
-    @Override
-    @Transactional
-    public QuestionCategory update(CustomUserDetails userDetails, Long itemId, QuestionCategoryRequestDto.UpdateDto request) {
-        memberService.checkSeller(userDetails);
-        Item item = checkInitial(itemId);
-
-        QuestionCategory questionCategory = questionCategoryRepository.findById(request.getId())
-                .orElseThrow(() -> new GeneralException(ErrorStatus.QUESTION_CATEGORY_NOT_FOUND));
-
-        if (!questionCategory.getItem().equals(item))
-            throw new GeneralException(ErrorStatus.INVALID_QUESTION_ITEM_RELATION);
-
-        if (request.getCategory() != null) questionCategory.setName(request.getCategory());
-
-        return questionCategory;
-    }
-
-    @Override
-    @Transactional
-    public void delete(CustomUserDetails userDetails, Long itemId, QuestionCategoryRequestDto.DeleteDto request) {
-        memberService.checkSeller(userDetails);
-        Item item = checkInitial(itemId);
-
-        QuestionCategory questionCategory = questionCategoryRepository.findById(request.getId())
-                .orElseThrow(() -> new GeneralException(ErrorStatus.QUESTION_CATEGORY_NOT_FOUND));
-        if (Objects.equals(questionCategory.getName(), "기타")) throw new GeneralException(ErrorStatus.ETC_IS_PINNED_CATEGORY);
-
-        item.getQuestionCategoryList().remove(questionCategory);
-        questionCategoryRepository.delete(questionCategory);
-    }
-
     @Override
     @Transactional(readOnly = true)
     public QuestionCategoryResponseDto.ListWithCntDto getList(Long sellerId, Long itemId) {

--- a/src/main/java/com/influy/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/influy/global/apiPayload/code/status/ErrorStatus.java
@@ -73,6 +73,7 @@ public enum ErrorStatus implements BaseCode {
     QUESTIONTAG_INVALID_RELATION(HttpStatus.BAD_REQUEST,"QUESTIONTAG INVALID RELATION", "해당 질문 태그를 조회할 수 없습니다."),
     ANSWER_NOT_FOUND(HttpStatus.NOT_FOUND, "ANSWER NOT FOUND", "해당 질문의 답변을 찾을 수 없습니다."),
     INVALID_TALKBOX_REQUEST(HttpStatus.BAD_REQUEST, "INVALID TALKBOX REQUEST", "다시 INITIAL로 되돌릴 수 없습니다."),
+    ETC_IS_PINNED_CATEGORY(HttpStatus.BAD_REQUEST, "ETC IS PINNED CATEGORY", "기타 카테고리는 삭제할 수 없습니다."),
 
     // 정렬 관련 응답
     UNSUPPORTED_SORT_TYPE(HttpStatus.BAD_REQUEST, "UNSUPPORTED SORT TYPE", "가능한 정렬이 아닙니다."),


### PR DESCRIPTION
## 💜 Related Issue

> #63

## 💜 Work Details

- [x] 셀러뷰 질문별 질문 조회 기능 (해당 질문 + 답변 리스트)
- [x] 톡박스 셀러가 질문 삭제, 톡박스 오픈 여부 수정 기능 위치 변경 (각각 Question, Item으로)
- [x] 톡박스 기본 멘트 설정 기능 
- [x] 내 상품 질문 관리창 기능
- [x] 아이템별 응답대기/응답완료/미확인 질문 관련 0으로 처리해뒀던거 모두 수정 

## 💜 Review Requirement

> 전체 테스트 완 :)
