### PR TITLE
#75 seller 홈 아이템별 질문 현황 api 구현

### DIFF
--- a/src/main/java/com/influy/domain/item/controller/ItemRestController.java
+++ b/src/main/java/com/influy/domain/item/controller/ItemRestController.java
@@ -6,7 +6,9 @@ import com.influy.domain.item.dto.ItemResponseDto;
 import com.influy.domain.item.entity.Item;
 import com.influy.domain.item.entity.TalkBoxOpenStatus;
 import com.influy.domain.item.service.ItemService;
+import com.influy.domain.member.service.MemberService;
 import com.influy.domain.sellerProfile.entity.ItemSortType;
+import com.influy.domain.sellerProfile.entity.SellerProfile;
 import com.influy.global.apiPayload.ApiResponse;
 import com.influy.global.common.PageRequestDto;
 import com.influy.global.jwt.CustomUserDetails;
@@ -24,6 +26,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class ItemRestController {
     private final ItemService itemService;
+    private final MemberService memberService;
 
     @PostMapping("/seller/items")
     @Operation(summary = "셀러 상품 상세정보 작성 후 생성")
@@ -154,4 +157,13 @@ public class ItemRestController {
                                                                                @RequestParam(name = "categoryId", required = false) Long categoryId) {
         return ApiResponse.onSuccess(itemService.getRecommended(userDetails, pageRequest, categoryId));
     }
+
+    @GetMapping("seller/home/questions")
+    @Operation(summary = "셀러 홈 상품 질문 안내", description = "아이템 별 많이 들어오는 질문 카테고리")
+    public ApiResponse<ItemResponseDto.SellerHomeItemPageDTO> getSellerHomeItem(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                                            @Valid @ParameterObject PageRequestDto pageRequestDto){
+        SellerProfile seller = memberService.checkSeller(userDetails);
+        return ApiResponse.onSuccess(itemService.getSellerHomeItemWithQuestionStatus(seller, pageRequestDto));
+    }
+
 }

--- a/src/main/java/com/influy/domain/item/converter/ItemConverter.java
+++ b/src/main/java/com/influy/domain/item/converter/ItemConverter.java
@@ -1,25 +1,20 @@
 package com.influy.domain.item.converter;
 
-import com.influy.domain.answer.dto.AnswerResponseDto;
-import com.influy.domain.faqCard.dto.FaqCardResponseDto;
 import com.influy.domain.item.dto.ItemRequestDto;
 import com.influy.domain.item.dto.ItemResponseDto;
+import com.influy.domain.item.dto.jpql.ItemJPQLResponse;
 import com.influy.domain.item.entity.Item;
 import com.influy.domain.image.entity.Image;
-import com.influy.domain.item.entity.ItemStatus;
-import com.influy.domain.item.entity.TalkBoxInfoPair;
 import com.influy.domain.item.entity.TalkBoxOpenStatus;
 import com.influy.domain.member.entity.Member;
 import com.influy.domain.member.entity.MemberRole;
 import com.influy.domain.sellerProfile.entity.SellerProfile;
-import io.swagger.v3.oas.annotations.media.Schema;
 import org.springframework.data.domain.Page;
 
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 public class ItemConverter {
     public static Item toItem(SellerProfile seller, ItemRequestDto.DetailDto request) {
@@ -221,6 +216,33 @@ public class ItemConverter {
                 .totalElements(itemPage == null ? 0: itemPage.getTotalElements())
                 .isFirst(itemPage == null || itemPage.isFirst())
                 .isLast(itemPage == null || itemPage.isLast())
+                .build();
+    }
+
+    public static ItemResponseDto.SellerHomeItemDTO toSellerHomeItemDTO(ItemJPQLResponse.ItemWithQuestionStatus itemJPQLResult, List<String> top2Categories) {
+
+        return ItemResponseDto.SellerHomeItemDTO.builder()
+                .itemId(itemJPQLResult.getItem().getId())
+                .imageUrl(itemJPQLResult.getItem().getImageList().getFirst().getImageLink())//리팩토링 필요
+                .itemTitle(itemJPQLResult.getItem().getName())
+                .itemStatus(itemJPQLResult.getItem().getItemStatus())
+                .itemPeriod(itemJPQLResult.getItem().getItemPeriod())
+                .endDate(itemJPQLResult.getItem().getEndDate())
+                .newQuestions(itemJPQLResult.getNewQuestions())
+                .totalPendingQuestions(itemJPQLResult.getPendingQuestions())
+                .top2Categories(top2Categories)
+                .build();
+    }
+
+    public static ItemResponseDto.SellerHomeItemPageDTO toSellerHomeItemPageDTO(Page<ItemJPQLResponse.ItemWithQuestionStatus> itmePage, Map<Long, List<String>> top2CategoryMap) {
+        List<ItemResponseDto.SellerHomeItemDTO> itemsList = itmePage.stream().map(item->toSellerHomeItemDTO(item, top2CategoryMap.get(item.getItem().getId()))).toList();
+        return ItemResponseDto.SellerHomeItemPageDTO.builder()
+                .itemList(itemsList)
+                .totalPage(itmePage.getTotalPages())
+                .totalElements(itmePage.getTotalElements())
+                .isFirst(itmePage.isFirst())
+                .isLast(itmePage.isLast())
+                .listSize(itemsList.size())
                 .build();
     }
 }

--- a/src/main/java/com/influy/domain/item/dto/ItemResponseDto.java
+++ b/src/main/java/com/influy/domain/item/dto/ItemResponseDto.java
@@ -14,6 +14,46 @@ import java.util.List;
 public class ItemResponseDto {
     @Getter
     @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SellerHomeItemPageDTO {
+        @Schema(description = "아이템 preview 리스트")
+        private List<SellerHomeItemDTO> itemList;
+
+        private Integer listSize;
+        private Integer totalPage;
+        private Long totalElements;
+        private Boolean isFirst;
+        private Boolean isLast;
+    }
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class SellerHomeItemDTO {
+        @Schema(description = "아이템 id", example = "1")
+        private Long itemId;
+        @Schema(description = "아이템 사진",example = "https://amazon~")
+        private String imageUrl;
+        @Schema(description = "아이템 상태", example = "DEFAULT")
+        private ItemStatus itemStatus;
+        @Schema(description = "아이템 진행 차수",example = "2")
+        private Integer itemPeriod;
+        @Schema(description = "상품 이름",example = "신나는 여행 패키지")
+        private String itemTitle;
+        @Schema(description = "마감 시간",example = "2025-09-20Z18:29:44")
+        private LocalDateTime endDate;
+        @Schema(description = "전체 질문(질문 대기)",example = "12")
+        private Long totalPendingQuestions;
+        @Schema(description = "확인하지 않은 질문 수",example = "3")
+        private Long newQuestions;
+        @Schema(description = "질문이 가장 많이 들어오는 2개 카테고리",example = "[\"일자 조정\",\"인원 수 문의\"]")
+        private List<String> top2Categories;
+    }
+
+
+    @Getter
+    @Builder
     @AllArgsConstructor
     @NoArgsConstructor
     public static class ResultDto {

--- a/src/main/java/com/influy/domain/item/dto/jpql/ItemJPQLResponse.java
+++ b/src/main/java/com/influy/domain/item/dto/jpql/ItemJPQLResponse.java
@@ -1,11 +1,21 @@
 package com.influy.domain.item.dto.jpql;
 
+import com.influy.domain.item.entity.Item;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @AllArgsConstructor
 @Getter
 public class ItemJPQLResponse {
-    private Boolean isArchived;
-    private Long count;
+    
+    public interface IsArchivedItemCount {
+        Boolean getIsArchived();
+        Long getCount();
+    }
+
+    public interface ItemWithQuestionStatus {
+        Item getItem();
+        Long getNewQuestions();
+        Long getPendingQuestions();
+    }
 }

--- a/src/main/java/com/influy/domain/item/repository/ItemRepository.java
+++ b/src/main/java/com/influy/domain/item/repository/ItemRepository.java
@@ -70,7 +70,7 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
         SUM(CASE WHEN q.isAnswered = false THEN 1 ELSE 0 END) AS pendingQuestions
     FROM Item i
     LEFT JOIN Question q ON q.item = i
-    WHERE i.seller.id = :sellerId
+    WHERE i.seller.id = :sellerId AND i.talkBoxOpenStatus = 'OPENED'
     GROUP BY i.id
     """, countQuery = """
         SELECT COUNT(i)

--- a/src/main/java/com/influy/domain/item/repository/ItemRepository.java
+++ b/src/main/java/com/influy/domain/item/repository/ItemRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.security.core.parameters.P;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -22,16 +23,15 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
     @Query("SELECT i FROM Item i WHERE i.seller.id = :sellerId AND i.isArchived = false AND i.endDate > :now")
     Page<Item> findOngoingItems(@Param("sellerId")Long sellerId, @Param("now")LocalDateTime now, Pageable pageable);
 
-    @Query("SELECT new com.influy.domain.item.dto.jpql.ItemJPQLResponse(p.isArchived, COUNT(p)) " +
-            "FROM Item p WHERE p.seller.id = :sellerId GROUP BY p.isArchived")
-    List<ItemJPQLResponse> countBySellerIdGroupByIsArchived(@Param("sellerId") Long sellerId);
+    @Query("SELECT p.isArchived AS isArchived, COUNT(p) AS count FROM Item p WHERE p.seller.id = :sellerId GROUP BY p.isArchived")
+    List<ItemJPQLResponse.IsArchivedItemCount> countBySellerIdGroupByIsArchived(@Param("sellerId") Long sellerId);
 
     boolean existsByIdAndSellerId(Long itemId, Long sellerId);
     @Query("SELECT i FROM Item i WHERE i.seller.id = :sellerId AND i.talkBoxOpenStatus = 'OPENED'")
     List<Item> findAllBySellerIdAndTalkBoxOpenStatus(@Param("sellerId")Long sellerId);
 
     @Query("SELECT i FROM Item i WHERE i.endDate > :now AND i.endDate <= :threshold AND i.itemStatus != 'SOLD_OUT' AND i.seller.isPublic = true")
-    Page<Item> findAllByEndDateAndItemStatus(LocalDateTime now, LocalDateTime threshold, Pageable pageable);
+    Page<Item> findAllByEndDateAndItemStatus(@Param("now") LocalDateTime now, @Param("threshold") LocalDateTime threshold, Pageable pageable);
 
     @Query("""
         SELECT i
@@ -43,7 +43,7 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
         GROUP BY i
         ORDER BY COUNT(q) DESC
     """)
-    Page<Item> findTop3ByQuestionCnt(LocalDateTime now, Pageable pageable);
+    Page<Item> findTop3ByQuestionCnt(@Param("now") LocalDateTime now, Pageable pageable);
 
     @Query("""
         SELECT ic.item FROM ItemCategory ic
@@ -53,14 +53,29 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
           AND ic.item.seller.isPublic = true
           ORDER BY ic.item.createdAt DESC
     """)
-    Page<Item> findAllByCategoryId(Long categoryId, Pageable pageable, LocalDateTime now);
+    Page<Item> findAllByCategoryId(@Param("categoryId") Long categoryId, Pageable pageable, @Param("now") LocalDateTime now);
 
     @Query("SELECT i FROM Item i WHERE i.endDate > :now AND i.itemStatus != 'SOLD_OUT' AND i.seller.isPublic = true")
-    Page<Item> findAllNow(Pageable pageable, LocalDateTime now);
+    Page<Item> findAllNow(Pageable pageable, @Param("now") LocalDateTime now);
 
     Boolean existsByNameContaining(String query);
 
     Page<Item> findAllByNameContainingOrSeller_Member_UsernameContainingOrSeller_Member_NicknameContainingOrSeller_InstagramContaining(String query, String query1, String query2, String query3, Pageable pageable);
 
     Optional<Item> findByIdAndSeller(Long itemId, SellerProfile seller);
+
+    @Query(value ="""
+    SELECT i AS item,
+        SUM(CASE WHEN q.isChecked = false THEN 1 ELSE 0 END) AS newQuestions,
+        SUM(CASE WHEN q.isAnswered = false THEN 1 ELSE 0 END) AS pendingQuestions
+    FROM Item i
+    LEFT JOIN Question q ON q.item = i
+    WHERE i.seller.id = :sellerId
+    GROUP BY i.id
+    """, countQuery = """
+        SELECT COUNT(i)
+        FROM Item i
+        WHERE i.seller.id = :sellerId
+        """)
+    Page<ItemJPQLResponse.ItemWithQuestionStatus> getItemsWithQuestionStatus(@Param("sellerId") Long sellerId, Pageable pageable);
 }

--- a/src/main/java/com/influy/domain/item/repository/ItemRepository.java
+++ b/src/main/java/com/influy/domain/item/repository/ItemRepository.java
@@ -72,6 +72,7 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
     LEFT JOIN Question q ON q.item = i
     WHERE i.seller.id = :sellerId AND i.talkBoxOpenStatus = 'OPENED'
     GROUP BY i.id
+    ORDER BY newQuestions
     """, countQuery = """
         SELECT COUNT(i)
         FROM Item i

--- a/src/main/java/com/influy/domain/item/service/ItemService.java
+++ b/src/main/java/com/influy/domain/item/service/ItemService.java
@@ -9,6 +9,7 @@ import com.influy.domain.item.entity.TalkBoxInfoPair;
 import com.influy.domain.item.entity.TalkBoxOpenStatus;
 import com.influy.domain.member.entity.Member;
 import com.influy.domain.sellerProfile.entity.ItemSortType;
+import com.influy.domain.sellerProfile.entity.SellerProfile;
 import com.influy.global.apiPayload.code.status.SuccessStatus;
 import com.influy.global.common.PageRequestDto;
 import com.influy.global.jwt.CustomUserDetails;
@@ -39,4 +40,6 @@ public interface ItemService {
     ItemResponseDto.HomeItemViewPageDto getRecommended(CustomUserDetails userDetails, PageRequestDto pageRequest, Long itemCategoryId);
     Item findById(Long itemId);
     List<Long> getLikeItems(CustomUserDetails userDetails);
+
+    ItemResponseDto.SellerHomeItemPageDTO getSellerHomeItemWithQuestionStatus(SellerProfile seller, PageRequestDto pageRequestDto);
 }

--- a/src/main/java/com/influy/domain/item/service/ItemServiceImpl.java
+++ b/src/main/java/com/influy/domain/item/service/ItemServiceImpl.java
@@ -376,11 +376,15 @@ public class ItemServiceImpl implements ItemService {
         Pageable pageable = pageRequestDto.toPageable();
         Page<ItemJPQLResponse.ItemWithQuestionStatus> items = itemRepository.getItemsWithQuestionStatus(seller.getId(), pageable);
         List<Long> itemIds = items.getContent().stream().map(item->item.getItem().getId()).toList();
-        List<CategoryJPQLResult.Top2Categories> top2Categories = questionCategoryRepository.getTop2CategoriesByNewQuestion(itemIds);
-
+        List<CategoryJPQLResult.Top2Categories> top2Categories;
         Map<Long,List<String>> top2CategoryMap = new HashMap<>();
-        for(CategoryJPQLResult.Top2Categories category : top2Categories) {
-            top2CategoryMap.computeIfAbsent(category.getItemId(),k->new ArrayList<>()).add(category.getCategoryName());
+
+        if(!itemIds.isEmpty()){
+            top2Categories = questionCategoryRepository.getTop2CategoriesByNewQuestion(itemIds);
+
+            for(CategoryJPQLResult.Top2Categories category : top2Categories) {
+                top2CategoryMap.computeIfAbsent(category.getItemId(),k->new ArrayList<>()).add(category.getCategoryName());
+            }
         }
 
         return ItemConverter.toSellerHomeItemPageDTO(items, top2CategoryMap);

--- a/src/main/java/com/influy/domain/item/service/ItemServiceImpl.java
+++ b/src/main/java/com/influy/domain/item/service/ItemServiceImpl.java
@@ -7,6 +7,7 @@ import com.influy.domain.image.entity.Image;
 import com.influy.domain.item.converter.ItemConverter;
 import com.influy.domain.item.dto.ItemRequestDto;
 import com.influy.domain.item.dto.ItemResponseDto;
+import com.influy.domain.item.dto.jpql.ItemJPQLResponse;
 import com.influy.domain.item.dto.jpql.TalkBoxInfoPairDto;
 import com.influy.domain.item.entity.Item;
 import com.influy.domain.item.entity.TalkBoxInfoPair;
@@ -20,6 +21,8 @@ import com.influy.domain.member.entity.MemberRole;
 import com.influy.domain.member.repository.MemberRepository;
 import com.influy.domain.member.service.MemberService;
 import com.influy.domain.question.repository.QuestionRepository;
+import com.influy.domain.questionCategory.dto.jpql.CategoryJPQLResult;
+import com.influy.domain.questionCategory.repository.QuestionCategoryRepository;
 import com.influy.domain.sellerProfile.entity.ItemSortType;
 import com.influy.domain.sellerProfile.entity.SellerProfile;
 import com.influy.domain.sellerProfile.repository.SellerProfileRepository;
@@ -51,6 +54,7 @@ public class ItemServiceImpl implements ItemService {
     private final MemberService memberService;
     private final QuestionRepository questionRepository;
     private final LikeRepository likeRepository;
+    private final QuestionCategoryRepository questionCategoryRepository;
 
     @Override
     @Transactional
@@ -365,5 +369,20 @@ public class ItemServiceImpl implements ItemService {
             likeItems = likeRepository.findLikedItemIdsByMember(member);
         }
         return likeItems;
+    }
+
+    @Override
+    public ItemResponseDto.SellerHomeItemPageDTO getSellerHomeItemWithQuestionStatus(SellerProfile seller, PageRequestDto pageRequestDto) {
+        Pageable pageable = pageRequestDto.toPageable();
+        Page<ItemJPQLResponse.ItemWithQuestionStatus> items = itemRepository.getItemsWithQuestionStatus(seller.getId(), pageable);
+        List<Long> itemIds = items.getContent().stream().map(item->item.getItem().getId()).toList();
+        List<CategoryJPQLResult.Top2Categories> top2Categories = questionCategoryRepository.getTop2CategoriesByNewQuestion(itemIds);
+
+        Map<Long,List<String>> top2CategoryMap = new HashMap<>();
+        for(CategoryJPQLResult.Top2Categories category : top2Categories) {
+            top2CategoryMap.computeIfAbsent(category.getItemId(),k->new ArrayList<>()).add(category.getCategoryName());
+        }
+
+        return ItemConverter.toSellerHomeItemPageDTO(items, top2CategoryMap);
     }
 }

--- a/src/main/java/com/influy/domain/member/controller/MemberController.java
+++ b/src/main/java/com/influy/domain/member/controller/MemberController.java
@@ -70,9 +70,9 @@ public class MemberController {
 
     @GetMapping("/auth/reissue")
     @Operation(summary = "액세스 토큰 재발급", description = "리프레시 토큰(쿠키)만 있으면 됨")
-    public ApiResponse<AuthResponseDTO.LoginResponse> reissueToken(@CookieValue("refreshToken")String refreshToken, HttpServletResponse response){
+    public ApiResponse<AuthResponseDTO.LoginResponse> reissueToken(HttpServletRequest request, HttpServletResponse response){
 
-        TokenPair tokenPair = authService.reissueToken(refreshToken, response);
+        TokenPair tokenPair = authService.reissueToken(request, response);
         Long memberId = jwtTokenProvider.getId(tokenPair.refreshToken());
         Member member = memberService.findById(memberId);
 

--- a/src/main/java/com/influy/domain/questionCategory/dto/jpql/CategoryJPQLResult.java
+++ b/src/main/java/com/influy/domain/questionCategory/dto/jpql/CategoryJPQLResult.java
@@ -12,4 +12,9 @@ public class CategoryJPQLResult {
         Boolean getIsAnswered();
         Long getTotalQuestions();
     }
+
+    public interface Top2Categories{
+        Long getItemId();
+        String getCategoryName();
+    }
 }

--- a/src/main/java/com/influy/domain/questionCategory/repository/QuestionCategoryRepository.java
+++ b/src/main/java/com/influy/domain/questionCategory/repository/QuestionCategoryRepository.java
@@ -35,4 +35,22 @@ public interface QuestionCategoryRepository extends JpaRepository<QuestionCatego
     Optional<QuestionCategory> findByIdAndItemId(Long questionCategoryId, Long itemId);
 
     List<QuestionCategory> findAllByItemId(Long itemId);
+
+    @Query(value = """
+    SELECT item_id AS itemId, category_name AS categoryName
+    FROM (
+        SELECT
+            q.item_id AS item_id,
+            c.name AS category_name,
+            RANK() OVER (PARTITION BY q.item_id ORDER BY COUNT(*) DESC) AS rk
+        FROM question q
+        JOIN question_tag qt ON q.question_tag_id = qt.id
+        JOIN question_category c ON qt.question_category_id = c.id
+        WHERE q.item_id IN (:itemIds)
+          AND q.is_checked = false
+        GROUP BY q.item_id, c.id
+    ) ranked
+    WHERE rk <= 2
+    """, nativeQuery = true)
+    List<CategoryJPQLResult.Top2Categories> getTop2CategoriesByNewQuestion(@Param("itemIds") List<Long> itemIds);
 }

--- a/src/main/java/com/influy/domain/sellerProfile/controller/SellerProfileController.java
+++ b/src/main/java/com/influy/domain/sellerProfile/controller/SellerProfileController.java
@@ -1,9 +1,8 @@
 package com.influy.domain.sellerProfile.controller;
 
-import com.influy.domain.item.dto.jpql.ItemJPQLResponse;
+import com.influy.domain.item.dto.jpql.ItemJPQLResponse.IsArchivedItemCount;
 import com.influy.domain.item.service.ItemService;
 import com.influy.domain.member.entity.Member;
-import com.influy.domain.member.entity.MemberRole;
 import com.influy.domain.member.service.MemberService;
 import com.influy.domain.sellerProfile.dto.SellerProfileRequestDTO;
 import com.influy.domain.sellerProfile.entity.ItemSortType;
@@ -73,7 +72,7 @@ public class SellerProfileController {
         SellerProfile seller = memberService.checkSeller(userDetails);
         boolean isLiked = sellerService.getIsLikedByMember(seller,seller.getMember());
 
-        List<ItemJPQLResponse> itemCountList = sellerService.getMarketItems(seller.getId());
+        List<IsArchivedItemCount> itemCountList = sellerService.getMarketItems(seller.getId());
         Long reviews = 0L;
 
         SellerProfileResponseDTO.MarketProfile body = SellerProfileConverter.toMarketProfileDTO(seller,isLiked,itemCountList, reviews);

--- a/src/main/java/com/influy/domain/sellerProfile/converter/SellerProfileConverter.java
+++ b/src/main/java/com/influy/domain/sellerProfile/converter/SellerProfileConverter.java
@@ -1,8 +1,7 @@
 package com.influy.domain.sellerProfile.converter;
-import com.influy.domain.item.dto.jpql.ItemJPQLResponse;
+import com.influy.domain.item.dto.jpql.ItemJPQLResponse.IsArchivedItemCount;
 import com.influy.domain.member.dto.MemberRequestDTO;
 import com.influy.domain.member.entity.Member;
-import com.influy.domain.sellerProfile.dto.SellerProfileRequestDTO;
 import com.influy.domain.sellerProfile.dto.SellerProfileResponseDTO;
 import com.influy.domain.sellerProfile.entity.SellerProfile;
 
@@ -50,12 +49,12 @@ public class SellerProfileConverter {
                 .build();
     }
 
-    public static SellerProfileResponseDTO.MarketProfile toMarketProfileDTO(SellerProfile seller, boolean isLiked, List<ItemJPQLResponse> itemCountList, Long reviews) {
+    public static SellerProfileResponseDTO.MarketProfile toMarketProfileDTO(SellerProfile seller, boolean isLiked, List<IsArchivedItemCount> itemCountList, Long reviews) {
         SellerProfileResponseDTO.SellerProfile sellerProfileDTO= toSellerProfileDTO(seller);
 
         Long publicItems = null;
         Long privateItems = null;
-        for(ItemJPQLResponse itemCount : itemCountList) {
+        for(IsArchivedItemCount itemCount : itemCountList) {
             if(itemCount.getIsArchived()){
                 privateItems = itemCount.getCount();
             }else {

--- a/src/main/java/com/influy/domain/sellerProfile/service/SellerProfileService.java
+++ b/src/main/java/com/influy/domain/sellerProfile/service/SellerProfileService.java
@@ -1,6 +1,6 @@
 package com.influy.domain.sellerProfile.service;
 
-import com.influy.domain.item.dto.jpql.ItemJPQLResponse;
+import com.influy.domain.item.dto.jpql.ItemJPQLResponse.IsArchivedItemCount;
 import com.influy.domain.member.dto.MemberRequestDTO;
 import com.influy.domain.member.entity.Member;
 import com.influy.domain.sellerProfile.dto.SellerProfileRequestDTO;
@@ -21,7 +21,7 @@ public interface SellerProfileService {
 
     boolean getIsLikedByMember(SellerProfile seller, Member member);
 
-    List<ItemJPQLResponse> getMarketItems(Long sellerId);
+    List<IsArchivedItemCount> getMarketItems(Long sellerId);
 
     Boolean checkQuestionOwner(Long tagId, Long categoryId, Long sellerId);
 }

--- a/src/main/java/com/influy/domain/sellerProfile/service/SellerProfileServiceImpl.java
+++ b/src/main/java/com/influy/domain/sellerProfile/service/SellerProfileServiceImpl.java
@@ -1,14 +1,11 @@
 package com.influy.domain.sellerProfile.service;
 
-import com.influy.domain.item.dto.jpql.ItemJPQLResponse;
-import com.influy.domain.item.entity.Item;
+import com.influy.domain.item.dto.jpql.ItemJPQLResponse.IsArchivedItemCount;
 import com.influy.domain.item.repository.ItemRepository;
 import com.influy.domain.like.entity.LikeStatus;
 import com.influy.domain.like.repository.LikeRepository;
 import com.influy.domain.member.dto.MemberRequestDTO;
 import com.influy.domain.member.entity.Member;
-import com.influy.domain.member.repository.MemberRepository;
-import com.influy.domain.member.service.MemberService;
 import com.influy.domain.sellerProfile.converter.SellerProfileConverter;
 import com.influy.domain.sellerProfile.dto.SellerProfileRequestDTO;
 import com.influy.domain.sellerProfile.entity.ItemSortType;
@@ -69,7 +66,7 @@ public class SellerProfileServiceImpl implements SellerProfileService {
     }
 
     @Override
-    public List<ItemJPQLResponse> getMarketItems(Long sellerId) {
+    public List<IsArchivedItemCount> getMarketItems(Long sellerId) {
         return itemRepository.countBySellerIdGroupByIsArchived(sellerId);
     }
 

--- a/src/main/java/com/influy/global/auth/service/AuthService.java
+++ b/src/main/java/com/influy/global/auth/service/AuthService.java
@@ -15,7 +15,7 @@ public interface AuthService {
 
     TokenPair issueToken(Member member);
 
-    TokenPair reissueToken(String token, HttpServletResponse response);
+    TokenPair reissueToken(HttpServletRequest request, HttpServletResponse response);
 
     void signOut(HttpServletRequest request, Member member);
 

--- a/src/main/java/com/influy/global/auth/service/KakaoAuthServiceImpl.java
+++ b/src/main/java/com/influy/global/auth/service/KakaoAuthServiceImpl.java
@@ -125,10 +125,10 @@ public class KakaoAuthServiceImpl implements AuthService {
     }
 
     @Override
-    public TokenPair reissueToken(String refreshToken, HttpServletResponse response) {
+    public TokenPair reissueToken(HttpServletRequest request, HttpServletResponse response) {
 
         // 1. 쿠키에서 토큰 가져오기
-        //String refreshToken = CookieUtil.extractRefreshTokenFromCookie(request);
+        String refreshToken = CookieUtil.extractRefreshTokenFromCookie(request);
         if (!jwtTokenProvider.validateToken(refreshToken)) {
             throw new GeneralException(ErrorStatus.UNAUTHORIZED);
         }


### PR DESCRIPTION
## 💜 Related Issue

> #75 

## 💜 Work Details

> 셀러 홈 화면의 아이템 별 질문 현황 구현

## 💜 Review Requirement

> item이 제 파트가 아니라 잘 몰랐는데 대표 사진 제공할때 늘 item.getImageList().getFirst()로 가져오더라구요.
지금 저장 로직을 어떻게 해놓으셨는지 자세히 확인해보지 않아서 잘은 모르지만 이미지 엔티티에 대표 사진 여부가 있는데 getFirst로 했을 때 이 대표사진 여부가 전혀 사용되지 않는것 같기도 하구... 결정적으로 아이템 프리뷰 리스트가 보여지는 화면이 너무 많아서 N+1 문제가 엄청 발생할 것 같은데 대표 사진만이라도 item쪽에 String 컬럼을 따로 만드는거 어떨까요?
엔티티 수정해야하는 부분이라 일단은 안고치고 기존 방식대로 구현해놨습니당
