### PR TITLE
#75 홈상품, 셀러 프로필 관련

### DIFF
--- a/src/main/java/com/influy/domain/item/controller/ItemRestController.java
+++ b/src/main/java/com/influy/domain/item/controller/ItemRestController.java
@@ -159,7 +159,7 @@ public class ItemRestController {
     }
 
     @GetMapping("seller/home/questions")
-    @Operation(summary = "셀러 홈 상품 질문 안내", description = "아이템 별 많이 들어오는 질문 카테고리")
+    @Operation(summary = "셀러 홈 상품 질문 안내", description = "아이템 + 아이템 별 많이 들어오는 질문 카테고리")
     public ApiResponse<ItemResponseDto.SellerHomeItemPageDTO> getSellerHomeItem(@AuthenticationPrincipal CustomUserDetails userDetails,
                                                                             @Valid @ParameterObject PageRequestDto pageRequestDto){
         SellerProfile seller = memberService.checkSeller(userDetails);

--- a/src/main/java/com/influy/domain/item/converter/ItemConverter.java
+++ b/src/main/java/com/influy/domain/item/converter/ItemConverter.java
@@ -217,7 +217,7 @@ public class ItemConverter {
                 .build();
     }
 
-    public static ItemResponseDto.SellerHomeItemDTO toSellerHomeItemDTO(ItemJPQLResponse.ItemWithQuestionStatus itemJPQLResult, List<String> top2Categories) {
+    public static ItemResponseDto.SellerHomeItemDTO toSellerHomeItemDTO(ItemJPQLResponse.ItemWithQuestionStatus itemJPQLResult, List<String> topNCategories) {
 
         return ItemResponseDto.SellerHomeItemDTO.builder()
                 .itemId(itemJPQLResult.getItem().getId())
@@ -225,15 +225,16 @@ public class ItemConverter {
                 .itemTitle(itemJPQLResult.getItem().getName())
                 .itemStatus(itemJPQLResult.getItem().getItemStatus())
                 .itemPeriod(itemJPQLResult.getItem().getItemPeriod())
+                .startDate(itemJPQLResult.getItem().getStartDate())
                 .endDate(itemJPQLResult.getItem().getEndDate())
                 .newQuestions(itemJPQLResult.getNewQuestions())
                 .totalPendingQuestions(itemJPQLResult.getPendingQuestions())
-                .top2Categories(top2Categories)
+                .topCategories(topNCategories)
                 .build();
     }
 
-    public static ItemResponseDto.SellerHomeItemPageDTO toSellerHomeItemPageDTO(Page<ItemJPQLResponse.ItemWithQuestionStatus> itmePage, Map<Long, List<String>> top2CategoryMap) {
-        List<ItemResponseDto.SellerHomeItemDTO> itemsList = itmePage.stream().map(item->toSellerHomeItemDTO(item, top2CategoryMap.get(item.getItem().getId()))).toList();
+    public static ItemResponseDto.SellerHomeItemPageDTO toSellerHomeItemPageDTO(Page<ItemJPQLResponse.ItemWithQuestionStatus> itmePage, Map<Long, List<String>> topNCategoryMap) {
+        List<ItemResponseDto.SellerHomeItemDTO> itemsList = itmePage.stream().map(item->toSellerHomeItemDTO(item, topNCategoryMap.get(item.getItem().getId()))).toList();
         return ItemResponseDto.SellerHomeItemPageDTO.builder()
                 .itemList(itemsList)
                 .totalPage(itmePage.getTotalPages())

--- a/src/main/java/com/influy/domain/item/dto/ItemResponseDto.java
+++ b/src/main/java/com/influy/domain/item/dto/ItemResponseDto.java
@@ -41,14 +41,16 @@ public class ItemResponseDto {
         private Integer itemPeriod;
         @Schema(description = "상품 이름",example = "신나는 여행 패키지")
         private String itemTitle;
+        @Schema(description = "시작 시간",example = "2025-05-20Z18:29:44")
+        private LocalDateTime startDate;
         @Schema(description = "마감 시간",example = "2025-09-20Z18:29:44")
         private LocalDateTime endDate;
         @Schema(description = "전체 질문(질문 대기)",example = "12")
         private Long totalPendingQuestions;
         @Schema(description = "확인하지 않은 질문 수",example = "3")
         private Long newQuestions;
-        @Schema(description = "질문이 가장 많이 들어오는 2개 카테고리",example = "[\"일자 조정\",\"인원 수 문의\"]")
-        private List<String> top2Categories;
+        @Schema(description = "질문이 가장 많이 들어오는 3개 카테고리",example = "[\"일자 조정\",\"인원 수 문의\"]")
+        private List<String> topCategories;
     }
 
 

--- a/src/main/java/com/influy/domain/item/repository/ItemRepository.java
+++ b/src/main/java/com/influy/domain/item/repository/ItemRepository.java
@@ -72,7 +72,7 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
     LEFT JOIN Question q ON q.item = i
     WHERE i.seller.id = :sellerId AND i.talkBoxOpenStatus = 'OPENED'
     GROUP BY i.id
-    ORDER BY newQuestions
+    ORDER BY newQuestions DESC, pendingQuestions DESC
     """, countQuery = """
         SELECT COUNT(i)
         FROM Item i

--- a/src/main/java/com/influy/domain/item/service/ItemServiceImpl.java
+++ b/src/main/java/com/influy/domain/item/service/ItemServiceImpl.java
@@ -360,19 +360,26 @@ public class ItemServiceImpl implements ItemService {
     @Override
     public ItemResponseDto.SellerHomeItemPageDTO getSellerHomeItemWithQuestionStatus(SellerProfile seller, PageRequestDto pageRequestDto) {
         Pageable pageable = pageRequestDto.toPageable();
+
+        //아이템 조회(1순위 isChecked=false 많은 순, 2순위 pendingQuestions 많은 순)
         Page<ItemJPQLResponse.ItemWithQuestionStatus> items = itemRepository.getItemsWithQuestionStatus(seller.getId(), pageable);
         List<Long> itemIds = items.getContent().stream().map(item->item.getItem().getId()).toList();
-        List<CategoryJPQLResult.Top2Categories> top2Categories;
-        Map<Long,List<String>> top2CategoryMap = new HashMap<>();
+
+        //현재 top3
+        List<CategoryJPQLResult.TopNCategories> topNCategories;
+        Map<Long,List<String>> topNCategoryMap = new HashMap<>();
 
         if(!itemIds.isEmpty()){
-            top2Categories = questionCategoryRepository.getTop2CategoriesByNewQuestion(itemIds);
+            topNCategories = questionCategoryRepository.getTopNCategoriesByNewQuestion(itemIds,3);
+            System.out.println(topNCategories.getFirst().getCategoryName());
 
-            for(CategoryJPQLResult.Top2Categories category : top2Categories) {
-                top2CategoryMap.computeIfAbsent(category.getItemId(),k->new ArrayList<>()).add(category.getCategoryName());
+            for(CategoryJPQLResult.TopNCategories category : topNCategories) {
+                topNCategoryMap.computeIfAbsent(category.getItemId(),k->new ArrayList<>()).add(category.getCategoryName());
+                System.out.println(category.getCategoryName());
             }
+
         }
 
-        return ItemConverter.toSellerHomeItemPageDTO(items, top2CategoryMap);
+        return ItemConverter.toSellerHomeItemPageDTO(items, topNCategoryMap);
     }
 }

--- a/src/main/java/com/influy/domain/questionCategory/dto/jpql/CategoryJPQLResult.java
+++ b/src/main/java/com/influy/domain/questionCategory/dto/jpql/CategoryJPQLResult.java
@@ -14,7 +14,7 @@ public class CategoryJPQLResult {
         Long getTotalQuestions();
     }
 
-    public interface Top2Categories{
+    public interface TopNCategories {
         Long getItemId();
         String getCategoryName();
     }

--- a/src/main/java/com/influy/domain/questionCategory/repository/QuestionCategoryRepository.java
+++ b/src/main/java/com/influy/domain/questionCategory/repository/QuestionCategoryRepository.java
@@ -1,6 +1,5 @@
 package com.influy.domain.questionCategory.repository;
 
-import com.influy.domain.item.entity.Item;
 import com.influy.domain.questionCategory.dto.jpql.CategoryJPQLResult;
 import com.influy.domain.questionCategory.entity.QuestionCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -40,20 +39,19 @@ public interface QuestionCategoryRepository extends JpaRepository<QuestionCatego
     List<QuestionCategory> findAllByItemId(Long itemId);
 
     @Query(value = """
-    SELECT item_id AS itemId, category_name AS categoryName
-    FROM (
-        SELECT
-            q.item_id AS item_id,
-            c.name AS category_name,
-            RANK() OVER (PARTITION BY q.item_id ORDER BY COUNT(*) DESC) AS rk
-        FROM question q
-        JOIN question_tag qt ON q.question_tag_id = qt.id
-        JOIN question_category c ON qt.question_category_id = c.id
-        WHERE q.item_id IN (:itemIds)
-          AND q.is_checked = false
-        GROUP BY q.item_id, c.id
-    ) ranked
-    WHERE rk <= 2
+    SELECT ITEM_ID AS itemId, CATEGORY_NAME AS categoryName
+      FROM
+        (SELECT q.item_id AS ITEM_ID, qc.name AS CATEGORY_NAME,
+           ROW_NUMBER() OVER (PARTITION BY q.item_id ORDER BY\s
+                  SUM(CASE WHEN q.is_checked = false THEN 1 ELSE 0 END) DESC,
+                  SUM(CASE WHEN q.is_answered = false THEN 1 ELSE 0 END) DESC
+              ) AS rk
+      FROM question q
+      JOIN question_tag qt ON q.question_tag_id = qt.id
+      JOIN question_category qc ON qt.question_category_id = qc.id
+      WHERE q.item_id IN (:itemIds)
+      GROUP BY q.item_id, qc.id, qc.name) sub
+    WHERE rk <= :n
     """, nativeQuery = true)
-    List<CategoryJPQLResult.Top2Categories> getTop2CategoriesByNewQuestion(@Param("itemIds") List<Long> itemIds);
+    List<CategoryJPQLResult.TopNCategories> getTopNCategoriesByNewQuestion(@Param("itemIds") List<Long> itemIds, @Param("n") Integer n);
 }

--- a/src/main/java/com/influy/domain/sellerProfile/controller/SellerProfileController.java
+++ b/src/main/java/com/influy/domain/sellerProfile/controller/SellerProfileController.java
@@ -105,4 +105,15 @@ public class SellerProfileController {
         return ApiResponse.onSuccess(body);
     }
 
+    @PutMapping("seller/isPublic")
+    @Operation(summary = "셀러 마켓 비공개 여부 수정 API", description = "비공개 시 홈에 안뜸")
+    public ApiResponse<SellerProfileResponseDTO.IsPublic> updateIsPublic(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                                         @RequestParam("status") Boolean status){
+
+        SellerProfile seller = memberService.checkSeller(userDetails);
+        SellerProfileResponseDTO.IsPublic body = SellerProfileConverter.toIsPublicDTO(sellerService.updateIsPublic(seller,status));
+
+        return ApiResponse.onSuccess(body);
+    }
+
 }

--- a/src/main/java/com/influy/domain/sellerProfile/converter/SellerProfileConverter.java
+++ b/src/main/java/com/influy/domain/sellerProfile/converter/SellerProfileConverter.java
@@ -88,4 +88,11 @@ public class SellerProfileConverter {
                 .reviews(reviews)
                 .build();
     }
+
+    public static SellerProfileResponseDTO.IsPublic toIsPublicDTO(SellerProfile sellerProfile) {
+        return SellerProfileResponseDTO.IsPublic.builder()
+                .sellerId(sellerProfile.getId())
+                .isPublic(sellerProfile.getIsPublic())
+                .build();
+    }
 }

--- a/src/main/java/com/influy/domain/sellerProfile/dto/SellerProfileResponseDTO.java
+++ b/src/main/java/com/influy/domain/sellerProfile/dto/SellerProfileResponseDTO.java
@@ -60,4 +60,14 @@ public class SellerProfileResponseDTO {
         @Schema(description = "아이템 정렬 타입", example = "END_DATE")
         private ItemSortType itemSortType;
     }
+
+    @Getter @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class IsPublic {
+        @Schema(description = "셀러(마켓) id", example = "1")
+        private Long sellerId;
+        @Schema(description = "공개 여부", example = "false")
+        private Boolean isPublic;
+    }
 }

--- a/src/main/java/com/influy/domain/sellerProfile/entity/SellerProfile.java
+++ b/src/main/java/com/influy/domain/sellerProfile/entity/SellerProfile.java
@@ -60,7 +60,6 @@ public class SellerProfile extends BaseEntity {
     @Builder.Default
     private List<Announcement> announcementList = new ArrayList<>();
 
-    //삭제하기
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "primary_announcement_id", unique = true)
     private Announcement primaryAnnouncement;
@@ -101,6 +100,11 @@ public class SellerProfile extends BaseEntity {
 
     public SellerProfile setItemSortType(ItemSortType type){
         this.itemSortType = type;
+        return this;
+    }
+
+    public SellerProfile setIsPublic(Boolean isPublic){
+        this.isPublic = isPublic;
         return this;
     }
 

--- a/src/main/java/com/influy/domain/sellerProfile/service/SellerProfileService.java
+++ b/src/main/java/com/influy/domain/sellerProfile/service/SellerProfileService.java
@@ -17,6 +17,8 @@ public interface SellerProfileService {
 
     SellerProfile updateItemSortType(SellerProfile sellerProfile, ItemSortType sortBy);
 
+    SellerProfile updateIsPublic(SellerProfile sellerProfile, Boolean isPublic);
+
     SellerProfile createSellerProfile(Member member, MemberRequestDTO.SellerJoin request);
 
     boolean getIsLikedByMember(SellerProfile seller, Member member);

--- a/src/main/java/com/influy/domain/sellerProfile/service/SellerProfileServiceImpl.java
+++ b/src/main/java/com/influy/domain/sellerProfile/service/SellerProfileServiceImpl.java
@@ -42,10 +42,18 @@ public class SellerProfileServiceImpl implements SellerProfileService {
         return sellerProfile.setProfile(request);
     }
 
+    @Override
     @Transactional
     public SellerProfile updateItemSortType(SellerProfile sellerProfile, ItemSortType sortBy) {
 
         return sellerProfile.setItemSortType(sortBy);
+    }
+
+    @Override
+    @Transactional
+    public SellerProfile updateIsPublic(SellerProfile sellerProfile, Boolean isPublic) {
+
+        return sellerProfile.setIsPublic(isPublic);
     }
 
 

--- a/src/main/java/com/influy/global/auth/tempInitializer/SellerInitializer.java
+++ b/src/main/java/com/influy/global/auth/tempInitializer/SellerInitializer.java
@@ -31,7 +31,7 @@ public class SellerInitializer implements CommandLineRunner {
 
     @Override
     public void run(String... args) throws Exception {
-        if (memberRepository.findByKakaoId(4339098764L).isEmpty()) {
+        /*if (memberRepository.findByKakaoId(4339098764L).isEmpty()) {
             ClassPathResource resource = new ClassPathResource("tempUser/FrontUser.json");
             if (!resource.exists()) {
                 throw new IOException("파일이 존재하지 않습니다.");
@@ -44,7 +44,7 @@ public class SellerInitializer implements CommandLineRunner {
 
             Member member = MemberConverter.toMember(dto.getUserInfo(), MemberRole.SELLER, "최서연");
             sellerProfileService.createSellerProfile(memberRepository.save(member),dto);
-        }
+        }*/
     }
 
 }


### PR DESCRIPTION
## 💜 Related Issue

> closes #75 

## 💜 Work Details

> 

- [x] 셀러 프로필 공개 여부 수정 api 구현
- [x] 프론트 개발자 셀러 가입용 이니셜라이저 삭제(혹시 나중에 데모데이때 필요할까봐 주석처리함)
- [x] 홈 셀러뷰 아이템 dto에 startDate 추가, top2Category를 top3로 변경
- [x] topNCategories 로직 변경: 새 질문 기준->1순위 새질문 2순위 pending 질문 기준  

## 💜 Review Requirement

> 궁금한 사항
