### PR TITLE
Admin 기능 구현

### DIFF
--- a/src/main/java/com/influy/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/influy/domain/admin/controller/AdminController.java
@@ -1,0 +1,71 @@
+package com.influy.domain.admin.controller;
+
+import com.influy.domain.admin.dto.AdminRequestDTO;
+import com.influy.domain.admin.service.AdminService;
+import com.influy.domain.item.converter.ItemConverter;
+import com.influy.domain.item.dto.ItemResponseDto;
+import com.influy.domain.item.entity.Item;
+import com.influy.domain.managerProfile.entity.ManagerProfile;
+import com.influy.domain.managerProfile.service.ManagerProfileService;
+import com.influy.domain.member.dto.MemberRequestDTO;
+import com.influy.domain.member.entity.Member;
+import com.influy.domain.member.entity.MemberRole;
+import com.influy.domain.member.service.MemberService;
+import com.influy.domain.sellerProfile.dto.SellerProfileResponseDTO;
+import com.influy.global.apiPayload.ApiResponse;
+import com.influy.global.apiPayload.code.status.ErrorStatus;
+import com.influy.global.apiPayload.exception.GeneralException;
+import com.influy.global.auth.TokenPair;
+import com.influy.global.auth.converter.AuthConverter;
+import com.influy.global.auth.dto.AuthResponseDTO;
+import com.influy.global.auth.service.AuthService;
+import com.influy.global.jwt.CookieUtil;
+import com.influy.global.jwt.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.tags.Tags;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin")
+@Tag(name="어드민")
+public class AdminController {
+
+    private final MemberService memberService;
+    private final AdminService adminService;
+    private final AuthService authService;
+    private final ManagerProfileService managerService;
+
+
+
+    @PostMapping("/register")
+    @Operation(summary = "어드민으로 승급", description = "회원 아이디로 어드민 지정")
+    public ApiResponse<List<AuthResponseDTO.SellerIdAndToken>> registerAdmin(@RequestBody List<Long> memberIds){
+        return null;
+    }
+
+    //본인 아이템 인가
+    @PostMapping("copy/items")
+    @Operation(summary = "어드민이 본인 아이템 인가")
+    public ApiResponse<List<ItemResponseDto.ResultDto>> copyItemToSeller(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                                   @RequestBody AdminRequestDTO.CopyItemToSeller request){
+        if(userDetails.getMember().getRole()!= MemberRole.ADMIN){
+            throw new GeneralException(ErrorStatus.ADMIN_REQUIRED);
+        }
+
+        List<Item> newItems = adminService.copyItemToSeller(request.getItemIds(), request.getSellerId());
+
+        List<ItemResponseDto.ResultDto> body  = newItems.stream().map(ItemConverter::toResultDto).toList();
+
+        return ApiResponse.onSuccess(body);
+    }
+    //가짜 셀러 생성
+    //다른 사람에게 셀러 위임
+    //
+}

--- a/src/main/java/com/influy/domain/admin/dto/AdminRequestDTO.java
+++ b/src/main/java/com/influy/domain/admin/dto/AdminRequestDTO.java
@@ -1,0 +1,27 @@
+package com.influy.domain.admin.dto;
+
+import com.influy.domain.member.dto.MemberRequestDTO;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
+import lombok.Getter;
+
+import java.util.List;
+
+public class AdminRequestDTO {
+
+    @Getter
+    public static class AdminJoin{
+        @Schema(description = "유저네임", example = "")
+        private String username;
+        @Schema(description = "멤버의 카카오 회원 번호", example = "1234567890")
+        private Long kakaoId;
+    }
+
+    @Getter
+    public static class CopyItemToSeller{
+        @Schema(description = "상품 인가할 셀러 아이디 리스트", example = "1")
+        private Long sellerId;
+        @Schema(description = "인가할 상품 아이디 리스트", example = "[1,2]")
+        private List<Long> itemIds;
+    }
+}

--- a/src/main/java/com/influy/domain/admin/service/AdminService.java
+++ b/src/main/java/com/influy/domain/admin/service/AdminService.java
@@ -1,0 +1,19 @@
+package com.influy.domain.admin.service;
+
+import com.influy.domain.admin.dto.AdminRequestDTO;
+import com.influy.domain.item.entity.Item;
+import com.influy.domain.managerProfile.entity.ManagerProfile;
+import com.influy.domain.member.converter.MemberConverter;
+import com.influy.domain.member.dto.MemberRequestDTO;
+import com.influy.domain.member.entity.Member;
+import com.influy.domain.sellerProfile.converter.SellerProfileConverter;
+import com.influy.domain.sellerProfile.entity.SellerProfile;
+
+import java.util.List;
+
+public interface AdminService {
+
+    Member joinAdmin(MemberRequestDTO.SellerJoin request);
+
+    List<Item> copyItemToSeller(List<Long> itemIds, Long sellerIds);
+}

--- a/src/main/java/com/influy/domain/admin/service/AdminServiceImpl.java
+++ b/src/main/java/com/influy/domain/admin/service/AdminServiceImpl.java
@@ -79,7 +79,7 @@ public class AdminServiceImpl implements AdminService {
 
             //이미지 복제해서 저장
             for(String imageURL : item.getImageList()){
-                String newImageURL = imageService.duplicateImg(imageURL);
+                String newImageURL = imageService.duplicateImg(imageURL,seller.getMember().getId());
                 newItem.getImageList().add(newImageURL);
             }
             newItem.setMainImg(newItem.getImageList().getFirst());

--- a/src/main/java/com/influy/domain/admin/service/AdminServiceImpl.java
+++ b/src/main/java/com/influy/domain/admin/service/AdminServiceImpl.java
@@ -1,0 +1,97 @@
+package com.influy.domain.admin.service;
+
+import com.influy.domain.admin.dto.AdminRequestDTO;
+import com.influy.domain.category.entity.Category;
+import com.influy.domain.category.repository.CategoryRepository;
+import com.influy.domain.image.service.ImageService;
+import com.influy.domain.item.converter.ItemConverter;
+import com.influy.domain.item.dto.ItemRequestDto;
+import com.influy.domain.item.entity.Item;
+import com.influy.domain.item.repository.ItemRepository;
+import com.influy.domain.item.service.ItemService;
+import com.influy.domain.item.service.ItemServiceImpl;
+import com.influy.domain.itemCategory.converter.ItemCategoryConverter;
+import com.influy.domain.itemCategory.entity.ItemCategory;
+import com.influy.domain.managerProfile.entity.ManagerProfile;
+import com.influy.domain.member.converter.MemberConverter;
+import com.influy.domain.member.dto.MemberRequestDTO;
+import com.influy.domain.member.entity.Member;
+import com.influy.domain.member.entity.MemberRole;
+import com.influy.domain.member.service.MemberService;
+import com.influy.domain.sellerProfile.converter.SellerProfileConverter;
+import com.influy.domain.sellerProfile.entity.SellerProfile;
+import com.influy.domain.sellerProfile.repository.SellerProfileRepository;
+import com.influy.domain.sellerProfile.service.SellerProfileService;
+import com.influy.global.apiPayload.code.status.ErrorStatus;
+import com.influy.global.apiPayload.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminServiceImpl implements AdminService {
+
+    private final MemberService memberService;
+    private final SellerProfileService sellerProfileService;
+    private final SellerProfileRepository sellerProfileRepository;
+    private final ItemRepository itemRepository;
+    private final ImageService imageService;
+    private final CategoryRepository categoryRepository;
+
+    @Override
+    @Transactional
+    public Member joinAdmin(MemberRequestDTO.SellerJoin request) {
+        if(sellerProfileRepository.existsByEmail(request.getEmail())){
+            throw new GeneralException(ErrorStatus.EMAIL_ALREADY_EXISTS);
+        }
+        if(sellerProfileRepository.existsByInstagram(request.getInstagram())){
+            throw new GeneralException(ErrorStatus.INSTAGRAM_ALREADY_EXISTS);
+        }
+        //어드민으로 가입
+        Member member = memberService.joinUser(request.getUserInfo(), MemberRole.ADMIN);
+
+        SellerProfile sellerProfile = sellerProfileService.createSellerProfile(member,request);
+        member.setSellerProfile(sellerProfile);
+
+        return member;
+    }
+
+    @Override
+    @Transactional
+    public List<Item> copyItemToSeller(List<Long> itemIds, Long sellerId) {
+        List<Item> items = itemRepository.findAllById(itemIds);
+
+        //길이가 다르면 없는 상품 존재하는 것
+        if(items.size()!=itemIds.size()){
+            throw new GeneralException(ErrorStatus.ITEM_NOT_FOUND);
+        }
+        SellerProfile seller = sellerProfileRepository.findById(sellerId).orElseThrow(() -> new GeneralException(ErrorStatus.SELLER_NOT_FOUND));
+
+        List<Item> newItems = new ArrayList<>();
+        for(Item item:items){
+            //내용 복사하여 새 아이템 생성
+            Item newItem = ItemConverter.duplicateItem(seller,item);
+
+            //이미지 복제해서 저장
+            for(String imageURL : item.getImageList()){
+                String newImageURL = imageService.duplicateImg(imageURL);
+                newItem.getImageList().add(newImageURL);
+            }
+
+            //카테고리 관계 설정
+            List<Category> categoryList = categoryRepository.findAllByItemId(item.getId());
+            List<ItemCategory> newItemCategoryList = categoryList.stream().map(category->ItemCategoryConverter.toItemCategory(category,newItem)).toList();
+            newItem.getItemCategoryList().addAll(newItemCategoryList);
+
+            newItems.add(itemRepository.save(newItem));
+            seller.getItemList().add(newItem);
+        }
+
+        return newItems;
+    }
+}

--- a/src/main/java/com/influy/domain/admin/service/AdminServiceImpl.java
+++ b/src/main/java/com/influy/domain/admin/service/AdminServiceImpl.java
@@ -82,6 +82,7 @@ public class AdminServiceImpl implements AdminService {
                 String newImageURL = imageService.duplicateImg(imageURL);
                 newItem.getImageList().add(newImageURL);
             }
+            newItem.setMainImg(newItem.getImageList().getFirst());
 
             //카테고리 관계 설정
             List<Category> categoryList = categoryRepository.findAllByItemId(item.getId());

--- a/src/main/java/com/influy/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/influy/domain/category/repository/CategoryRepository.java
@@ -2,8 +2,19 @@ package com.influy.domain.category.repository;
 
 import com.influy.domain.category.entity.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+    @Query("""
+    SELECT c
+    FROM Category c
+    JOIN ItemCategory ic ON ic.category = c
+    WHERE ic.item.id = :itemId
+    """)
+    List<Category> findAllByItemId(@Param("itemId") Long itemId);
 }

--- a/src/main/java/com/influy/domain/image/service/ImageService.java
+++ b/src/main/java/com/influy/domain/image/service/ImageService.java
@@ -8,4 +8,6 @@ import java.net.URL;
 
 public interface ImageService {
     ImageResponseDto.UploadResultDto uploadImg(CustomUserDetails userDetails, ImageRequestDto.UploadDto request);
+
+    String duplicateImg(String sourceURL);
 }

--- a/src/main/java/com/influy/domain/image/service/ImageService.java
+++ b/src/main/java/com/influy/domain/image/service/ImageService.java
@@ -9,5 +9,5 @@ import java.net.URL;
 public interface ImageService {
     ImageResponseDto.UploadResultDto uploadImg(CustomUserDetails userDetails, ImageRequestDto.UploadDto request);
 
-    String duplicateImg(String sourceURL);
+    String duplicateImg(String sourceURL,Long memberId);
 }

--- a/src/main/java/com/influy/domain/image/service/ImageServiceImpl.java
+++ b/src/main/java/com/influy/domain/image/service/ImageServiceImpl.java
@@ -3,11 +3,15 @@ package com.influy.domain.image.service;
 import com.influy.domain.image.converter.ImageConverter;
 import com.influy.domain.image.dto.ImageRequestDto;
 import com.influy.domain.image.dto.ImageResponseDto;
+import com.influy.global.apiPayload.code.status.ErrorStatus;
+import com.influy.global.apiPayload.exception.GeneralException;
 import com.influy.global.jwt.CustomUserDetails;
 import org.springframework.beans.factory.annotation.Value;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
@@ -25,6 +29,7 @@ public class ImageServiceImpl implements ImageService {
     private String region;
 
     private final S3Presigner s3Presigner;
+    private final S3Client s3Client;
 
     @Override
     @Transactional
@@ -42,5 +47,37 @@ public class ImageServiceImpl implements ImageService {
         String imageUrl = "https://" + bucket + ".s3." + region + ".amazonaws.com/" + fullPath;
 
         return ImageConverter.toUploadResultDto(presignedRequest.url(), imageUrl);
+    }
+
+    @Override
+    @Transactional  //이미지 경로 리팩 제안
+    public String duplicateImg(String sourceURL) {
+
+
+        String keyPrefix = "https://" + bucket + ".s3.region.amazonaws.com/"; // URL 패턴
+
+        if(!sourceURL.startsWith(keyPrefix)) {
+            throw new GeneralException(ErrorStatus.INVALID_IMAGE_URL);
+        }
+        String sourceKey = sourceURL.replace(keyPrefix, ""); // "items/1234/image1.jpg"
+
+        String original = sourceURL.substring(sourceURL.lastIndexOf('/') + 1);// 123e4567-influy.png
+        String baseName = original.substring(0, original.lastIndexOf('.')); // influy
+        String extension = original.substring(original.lastIndexOf('.') + 1); // png
+
+        String destinationKey = "image-src/" + UUID.randomUUID() + "-" + baseName + "." + extension; // image-src/123e4567-influy.png
+        String imageUrl = "https://" + bucket + ".s3." + region + ".amazonaws.com/" + destinationKey;
+
+        CopyObjectRequest copyReq = CopyObjectRequest.builder()
+                .sourceBucket(bucket)
+                .sourceKey(sourceKey)
+                .destinationBucket(bucket)
+                .destinationKey(destinationKey)
+                .build();
+
+        s3Client.copyObject(copyReq);
+
+        return imageUrl;
+
     }
 }

--- a/src/main/java/com/influy/domain/image/service/ImageServiceImpl.java
+++ b/src/main/java/com/influy/domain/image/service/ImageServiceImpl.java
@@ -54,7 +54,7 @@ public class ImageServiceImpl implements ImageService {
     public String duplicateImg(String sourceURL) {
 
 
-        String keyPrefix = "https://" + bucket + ".s3.region.amazonaws.com/"; // URL 패턴
+        String keyPrefix = "https://" + bucket + ".s3."+region+".amazonaws.com/"; // URL 패턴
 
         if(!sourceURL.startsWith(keyPrefix)) {
             throw new GeneralException(ErrorStatus.INVALID_IMAGE_URL);

--- a/src/main/java/com/influy/domain/image/service/ImageServiceImpl.java
+++ b/src/main/java/com/influy/domain/image/service/ImageServiceImpl.java
@@ -38,7 +38,7 @@ public class ImageServiceImpl implements ImageService {
         String baseName = original.substring(0, original.lastIndexOf('.')); // influy
         String extension = original.substring(original.lastIndexOf('.') + 1); // png
 
-        String fullPath = "image-src/" + UUID.randomUUID() + "-" + baseName + "." + extension; // image-src/123e4567-influy.png
+        String fullPath = "image-src/user-" + userDetails.getId() + "/" + UUID.randomUUID() + "-" + baseName + "." + extension; // image-src/user-1/123e4567-influy.png
 
         PutObjectRequest objectRequest = ImageConverter.toPutObjectRequest(bucket, fullPath, extension);
         PutObjectPresignRequest presignRequest = ImageConverter.toPutObjectPresignRequest(objectRequest);
@@ -51,7 +51,7 @@ public class ImageServiceImpl implements ImageService {
 
     @Override
     @Transactional  //이미지 경로 리팩 제안
-    public String duplicateImg(String sourceURL) {
+    public String duplicateImg(String sourceURL, Long memberId) {
 
 
         String keyPrefix = "https://" + bucket + ".s3."+region+".amazonaws.com/"; // URL 패턴
@@ -65,7 +65,7 @@ public class ImageServiceImpl implements ImageService {
         String baseName = original.substring(0, original.lastIndexOf('.')); // influy
         String extension = original.substring(original.lastIndexOf('.') + 1); // png
 
-        String destinationKey = "image-src/" + UUID.randomUUID() + "-" + baseName + "." + extension; // image-src/123e4567-influy.png
+        String destinationKey = "image-src/user-" + memberId + "/" + UUID.randomUUID() + "-" + baseName + "." + extension; // image-src/user-1/123e4567-influy.png
         String imageUrl = "https://" + bucket + ".s3." + region + ".amazonaws.com/" + destinationKey;
 
         CopyObjectRequest copyReq = CopyObjectRequest.builder()

--- a/src/main/java/com/influy/domain/item/converter/ItemConverter.java
+++ b/src/main/java/com/influy/domain/item/converter/ItemConverter.java
@@ -198,6 +198,8 @@ public class ItemConverter {
                 .marketLink(item.getMarketLink())
                 .comment(item.getComment())
                 .isArchived(item.getIsArchived())
+                .itemStatus(item.getItemStatus())
+                .isDateUndefined(item.getIsDateUndefined())
                 .build();
 
     }

--- a/src/main/java/com/influy/domain/item/converter/ItemConverter.java
+++ b/src/main/java/com/influy/domain/item/converter/ItemConverter.java
@@ -12,6 +12,7 @@ import com.influy.domain.sellerProfile.entity.SellerProfile;
 import org.springframework.data.domain.Page;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -181,5 +182,23 @@ public class ItemConverter {
                 .cnt(itemList.size())
                 .talkBoxOpenedDtoList(itemDtoList)
                 .build();
+    }
+
+    public static Item duplicateItem(SellerProfile seller, Item item) {
+
+        return Item.builder()
+                .seller(seller)
+                .name(item.getName())
+                .regularPrice(item.getRegularPrice())
+                .salePrice(item.getSalePrice())
+                .tagline(item.getTagline())
+                .startDate(item.getStartDate())
+                .endDate(item.getEndDate())
+                .itemPeriod(item.getItemPeriod())
+                .marketLink(item.getMarketLink())
+                .comment(item.getComment())
+                .isArchived(item.getIsArchived())
+                .build();
+
     }
 }

--- a/src/main/java/com/influy/domain/item/entity/Item.java
+++ b/src/main/java/com/influy/domain/item/entity/Item.java
@@ -46,6 +46,9 @@ public class Item extends BaseEntity {
     private LocalDateTime endDate;
 
     @Builder.Default
+    private Boolean isDateUndefined = false;
+
+    @Builder.Default
     @Setter
     private Boolean archiveRecommended = true;
 

--- a/src/main/java/com/influy/domain/item/service/ItemServiceImpl.java
+++ b/src/main/java/com/influy/domain/item/service/ItemServiceImpl.java
@@ -67,6 +67,7 @@ public class ItemServiceImpl implements ItemService {
         seller.getItemList().add(item);
 
         return item;
+
     }
 
     @Override
@@ -214,7 +215,10 @@ public class ItemServiceImpl implements ItemService {
 
     private void createItemImgList(ItemRequestDto.DetailDto request, Item item) {
         item.getImageList().addAll(request.getItemImgList());
-        item.setMainImg(item.getImageList().getFirst());
+        if(!item.getImageList().isEmpty()){
+            item.setMainImg(item.getImageList().getFirst());
+        }
+
     }
 
     @Override

--- a/src/main/java/com/influy/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/influy/domain/like/repository/LikeRepository.java
@@ -50,6 +50,7 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
         FROM Like l
         WHERE l.member = :member
           AND l.targetType = 'SELLER'
+          AND l.likeStatus = 'LIKE'
     """)
     List<Long> findLikedSellerIdsByMember(@Param("member") Member member);
 
@@ -58,6 +59,7 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
         FROM Like l
         WHERE l.member = :member
           AND l.targetType = 'ITEM'
+          AND l.likeStatus = 'LIKE'
     """)
     List<Long> findLikedItemIdsByMember(@Param("member")Member member);
 }

--- a/src/main/java/com/influy/domain/managerProfile/converter/ManagerProfileConverter.java
+++ b/src/main/java/com/influy/domain/managerProfile/converter/ManagerProfileConverter.java
@@ -1,0 +1,12 @@
+package com.influy.domain.managerProfile.converter;
+
+import com.influy.domain.managerProfile.entity.ManagerProfile;
+import com.influy.domain.member.entity.Member;
+
+public class ManagerProfileConverter {
+    public static ManagerProfile toManagerProfile(Member member) {
+        return ManagerProfile.builder()
+                .member(member)
+                .build();
+    }
+}

--- a/src/main/java/com/influy/domain/managerProfile/repository/ManagerProfileRepository.java
+++ b/src/main/java/com/influy/domain/managerProfile/repository/ManagerProfileRepository.java
@@ -1,0 +1,7 @@
+package com.influy.domain.managerProfile.repository;
+
+import com.influy.domain.managerProfile.entity.ManagerProfile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ManagerProfileRepository extends JpaRepository<ManagerProfile, Long> {
+}

--- a/src/main/java/com/influy/domain/managerProfile/service/ManagerProfileService.java
+++ b/src/main/java/com/influy/domain/managerProfile/service/ManagerProfileService.java
@@ -1,0 +1,10 @@
+package com.influy.domain.managerProfile.service;
+
+import com.influy.domain.managerProfile.entity.ManagerProfile;
+import com.influy.domain.member.entity.Member;
+
+public interface ManagerProfileService {
+    ManagerProfile joinManager(Member member);
+    ManagerProfile getManagerProfileByMemberId(Long id);
+
+}

--- a/src/main/java/com/influy/domain/managerProfile/service/ManagerProfileServiceImpl.java
+++ b/src/main/java/com/influy/domain/managerProfile/service/ManagerProfileServiceImpl.java
@@ -1,0 +1,30 @@
+package com.influy.domain.managerProfile.service;
+
+import com.influy.domain.managerProfile.converter.ManagerProfileConverter;
+import com.influy.domain.managerProfile.entity.ManagerProfile;
+import com.influy.domain.managerProfile.repository.ManagerProfileRepository;
+import com.influy.domain.member.entity.Member;
+import com.influy.global.apiPayload.code.status.ErrorStatus;
+import com.influy.global.apiPayload.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ManagerProfileServiceImpl implements ManagerProfileService {
+
+    private final ManagerProfileRepository managerProfileRepository;
+
+    @Override
+    @Transactional
+    public ManagerProfile joinManager(Member member) {
+        return ManagerProfileConverter.toManagerProfile(member);
+    }
+
+    @Override
+    public ManagerProfile getManagerProfileByMemberId(Long id) {
+        return managerProfileRepository.findById(id).orElseThrow(()->new GeneralException(ErrorStatus.MANAGER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/influy/domain/member/controller/MemberController.java
+++ b/src/main/java/com/influy/domain/member/controller/MemberController.java
@@ -93,7 +93,7 @@ public class MemberController {
 
         if(member.getRole()==MemberRole.USER){
             body = AuthConverter.toUserIdAndTokenDto(memberId, tokenPair.accessToken());
-        }else if(member.getRole()==MemberRole.SELLER){
+        }else if(member.getRole()==MemberRole.SELLER||member.getRole()==MemberRole.ADMIN){
             body = AuthConverter.toSellerIdAndToken(memberId,member.getSellerProfile().getId(),tokenPair.accessToken());
         }
 

--- a/src/main/java/com/influy/domain/member/controller/MemberController.java
+++ b/src/main/java/com/influy/domain/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.influy.domain.member.controller;
 
 
+import com.influy.domain.admin.service.AdminService;
 import com.influy.domain.member.converter.MemberConverter;
 import com.influy.domain.member.dto.MemberRequestDTO;
 import com.influy.domain.member.dto.MemberResponseDTO;
@@ -38,6 +39,7 @@ public class MemberController {
     private final MemberService memberService;
     private final AuthService authService;
     private final JwtTokenProvider jwtTokenProvider;
+    private final AdminService adminService;
 
     //일반 유저 가입
     @PostMapping("/register/user")
@@ -64,6 +66,17 @@ public class MemberController {
         AuthResponseDTO.SellerIdAndToken body = AuthConverter.toSellerIdAndToken(member.getId(), sellerProfile.getId(), tokenPair.accessToken());
 
         CookieUtil.refreshTokenInCookie(response, tokenPair.refreshToken());
+
+        return ApiResponse.onSuccess(body);
+    }
+    @PostMapping("/register/admin")
+    @Operation(summary = "어드민 회원 가입")
+    public ApiResponse<AuthResponseDTO.SellerIdAndToken> signUpAdmin(@RequestBody MemberRequestDTO.SellerJoin request, HttpServletResponse response) {
+
+        Member member = adminService.joinAdmin(request);
+        TokenPair token = authService.issueToken(member);
+        AuthResponseDTO.SellerIdAndToken body = AuthConverter.toSellerIdAndToken(member.getId(),member.getSellerProfile().getId(), token.accessToken());
+        CookieUtil.refreshTokenInCookie(response,token.refreshToken());
 
         return ApiResponse.onSuccess(body);
     }

--- a/src/main/java/com/influy/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/influy/domain/member/service/MemberServiceImpl.java
@@ -134,7 +134,7 @@ public class MemberServiceImpl implements MemberService {
 
         Member member = userDetails.getMember();
 
-        if (member.getRole() == MemberRole.SELLER || member.getRole() == MemberRole.MANAGER) {
+        if (member.getRole() == MemberRole.SELLER || member.getRole() == MemberRole.MANAGER||member.getRole()==MemberRole.ADMIN) {
             return sellerProfileRepository.findByMemberId(member.getId())
                     .orElseThrow(() -> new GeneralException(ErrorStatus.SELLER_NOT_FOUND));
         } else {

--- a/src/main/java/com/influy/domain/sellerProfile/controller/SellerProfileController.java
+++ b/src/main/java/com/influy/domain/sellerProfile/controller/SellerProfileController.java
@@ -29,19 +29,6 @@ public class SellerProfileController {
     private final MemberService memberService;
     private final ItemService itemService;
 
-
-    //프로필 조회
-    @GetMapping("seller/profile")
-    @Operation(summary = "셀러 프로필 수정 시 기본값 조회 API", description = "셀러 본인만 가능")
-    public ApiResponse<SellerProfileResponseDTO.SellerProfile> getSellerProfile(@AuthenticationPrincipal CustomUserDetails userDetails) {
-
-
-        SellerProfile seller = memberService.checkSeller(userDetails);
-        SellerProfileResponseDTO.SellerProfile body = SellerProfileConverter.toSellerProfileDTO(seller);
-
-        return ApiResponse.onSuccess(body);
-    }
-
     //일반 유저의 프로필 조회
     @GetMapping("user/{sellerId}/market")
     @Operation(summary = "셀러 마켓 조회 API", description = "일반 사용자가 셀러 마켓 들어갔을 때")
@@ -60,6 +47,18 @@ public class SellerProfileController {
         SellerProfileResponseDTO.MarketProfile body = SellerProfileConverter.toMarketProfileDTO(seller,isLiked, publicItems, reviews);
 
 
+
+        return ApiResponse.onSuccess(body);
+    }
+
+    //프로필 조회
+    @GetMapping("seller/profile")
+    @Operation(summary = "셀러 프로필 수정 시 기본값 조회 API", description = "셀러 본인만 가능")
+    public ApiResponse<SellerProfileResponseDTO.SellerProfile> getSellerProfile(@AuthenticationPrincipal CustomUserDetails userDetails) {
+
+
+        SellerProfile seller = memberService.checkSeller(userDetails);
+        SellerProfileResponseDTO.SellerProfile body = SellerProfileConverter.toSellerProfileDTO(seller);
 
         return ApiResponse.onSuccess(body);
     }

--- a/src/main/java/com/influy/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/influy/global/apiPayload/code/status/ErrorStatus.java
@@ -93,7 +93,16 @@ public enum ErrorStatus implements BaseCode {
     //API 요청 관련 에러 응답
     NEED_TO_SIGN_UP(HttpStatus.OK,"NEED_TO_SIGN_UP" ,"회원이 아닙니다." ),
     GET_KAKAO_TOKEN_FAILED(HttpStatus.BAD_REQUEST,"GET KAKAO TOKEN FAILED" ,"카카오 로그인 토큰을 요청하는 과정에서 문제가 일어났습니다." ),
-    GET_KAKAO_USER_PROFILE_FAILED(HttpStatus.BAD_REQUEST,"GET KAKAO USER PROFILE FAILED" ,"카카오 유저 정보를 조회하는 과정에서 문제가 일어났습니다." );
+    GET_KAKAO_USER_PROFILE_FAILED(HttpStatus.BAD_REQUEST,"GET KAKAO USER PROFILE FAILED" ,"카카오 유저 정보를 조회하는 과정에서 문제가 일어났습니다." ),
+
+    //어드민 관련 응답
+    ADMIN_REQUIRED(HttpStatus.FORBIDDEN,"ADMIN REQUIRED" ,"어드민만 사용할 수 있는 기능입니다." ),
+
+    //매니저 관련 응답
+    MANAGER_NOT_FOUND(HttpStatus.NOT_FOUND,"MANAGER NOT FOUND" , "매니저를 찾을 수 없습니다"),
+
+    //이미지 관련 응답
+    INVALID_IMAGE_URL(HttpStatus.BAD_REQUEST,"INVALID IMAGE URL" ,"정상적인 이미지 URL이 아닙니다." );
 
 
 

--- a/src/main/java/com/influy/global/auth/tempInitializer/SellerInitializer.java
+++ b/src/main/java/com/influy/global/auth/tempInitializer/SellerInitializer.java
@@ -31,7 +31,7 @@ public class SellerInitializer implements CommandLineRunner {
 
     @Override
     public void run(String... args) throws Exception {
-        /*if (memberRepository.findByKakaoId(4339098764L).isEmpty()) {
+        if (memberRepository.findByKakaoId(4339098764L).isEmpty()) {
             ClassPathResource resource = new ClassPathResource("tempUser/FrontUser.json");
             if (!resource.exists()) {
                 throw new IOException("파일이 존재하지 않습니다.");
@@ -44,7 +44,7 @@ public class SellerInitializer implements CommandLineRunner {
 
             Member member = MemberConverter.toMember(dto.getUserInfo(), MemberRole.SELLER, "최서연");
             sellerProfileService.createSellerProfile(memberRepository.save(member),dto);
-        }*/
+        }
     }
 
 }

--- a/src/main/java/com/influy/global/auth/tempInitializer/SellerInitializer.java
+++ b/src/main/java/com/influy/global/auth/tempInitializer/SellerInitializer.java
@@ -31,7 +31,7 @@ public class SellerInitializer implements CommandLineRunner {
 
     @Override
     public void run(String... args) throws Exception {
-        if (memberRepository.findByKakaoId(4339098764L).isEmpty()) {
+        /*if (memberRepository.findByKakaoId(4339098764L).isEmpty()) {
             ClassPathResource resource = new ClassPathResource("tempUser/FrontUser.json");
             if (!resource.exists()) {
                 throw new IOException("파일이 존재하지 않습니다.");
@@ -44,7 +44,7 @@ public class SellerInitializer implements CommandLineRunner {
 
             Member member = MemberConverter.toMember(dto.getUserInfo(), MemberRole.SELLER, "최서연");
             sellerProfileService.createSellerProfile(memberRepository.save(member),dto);
-        }
+        }*/
     }
 
 }

--- a/src/main/java/com/influy/global/config/S3Config.java
+++ b/src/main/java/com/influy/global/config/S3Config.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
@@ -23,6 +24,15 @@ public class S3Config {
     public S3Presigner s3Presigner() {
         AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
         return S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .build();
+    }
+
+    @Bean
+    public S3Client s3Client(){
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
+        return S3Client.builder()
                 .region(Region.of(region))
                 .credentialsProvider(StaticCredentialsProvider.create(credentials))
                 .build();


### PR DESCRIPTION
## 💜 Related Issue

> #98

## 💜 Work Details

> - [x] 어드민 가입
> - [x] 어드민이 모든 유저/셀러 기능 가능하도록 검증 로직 수정
> - [x] 어드민이 직접 생성한 아이템 인가 가능

## 💜 Review Requirement

1. s3 이미지 삭제 로직이 현재 없는데, 저희 DB에서는 지금 element collection으로 모든 리스트 한번에 삭제+결과 리스트 다시 모두 저장 하는 식으로 하고 있지만 s3 삭제는 이전 리스트-현재 리스트 비교해서 없어진 파일만 한번에 삭제하도록 로직 짜는게 좋을 것 같습니다!
2. 이미지 저장 경로를 UUID.RandomUUID만 쓰고 있던데 모든 이미지를 한 폴더안에 넣고 있는것 같아서요.. 이왕 userDetails 받는거 fullPath에 memberId 넣는거 어떻게 생각하시나요? [참고블로그](https://yubi5050.tistory.com/315)
3. 기획쪽에서 아이템 인가를 먼저 완료해달라고 했고 이제 디비 초기화 하지 말아달라고 해서 일단은 아이템 인가만 완료하는 상태로 마무리하면 될것같습니다
