### PR TITLE
#66 feat : 유저가 톡박스 리스트(내가 한 질문) 조회 구현

### DIFF
--- a/src/main/java/com/influy/domain/answer/converter/AnswerConverter.java
+++ b/src/main/java/com/influy/domain/answer/converter/AnswerConverter.java
@@ -32,10 +32,11 @@ public class AnswerConverter {
                 .build();
     }
 
-    public static AnswerResponseDto.AnswerTagListDto toAnswerTagListDto(QuestionTag questionTag, List<Answer> answerList) {
+    public static AnswerResponseDto.AnswerTagListDto toAnswerTagListDto(String categoryName, QuestionTag questionTag, List<Answer> answerList) {
         List<String> contentList = answerList.stream().map(Answer::getContent).toList();
 
         return AnswerResponseDto.AnswerTagListDto.builder()
+                .category(categoryName)
                 .tag(questionTag.getName())
                 .answerList(contentList)
                 .build();

--- a/src/main/java/com/influy/domain/answer/converter/AnswerConverter.java
+++ b/src/main/java/com/influy/domain/answer/converter/AnswerConverter.java
@@ -79,4 +79,10 @@ public class AnswerConverter {
                 .createdAt(answer.getCreatedAt())
                 .build();
     }
+    public static AnswerResponseDto.UserViewGreeting toUserViewGreetingDTO(String greeting) {
+        return AnswerResponseDto.UserViewGreeting.builder()
+                .type("Default Message")
+                .content(greeting)
+                .build();
+    }
 }

--- a/src/main/java/com/influy/domain/answer/dto/AnswerResponseDto.java
+++ b/src/main/java/com/influy/domain/answer/dto/AnswerResponseDto.java
@@ -53,6 +53,17 @@ public class AnswerResponseDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    public static class UserViewGreeting implements QuestionResponseDTO.UserViewQNA{
+        @Schema(description = "타입", example = "Default Message")
+        private String type;
+        @Schema(description = "기본 멘트 내용", example = "빠른 확인이 불가할 수 있습니다.")
+        private String content;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class AnswerCommonResultDto {
         @Schema(description = "답변한 질문 개수", example = "4")
         private Integer answeredCnt;

--- a/src/main/java/com/influy/domain/answer/dto/AnswerResponseDto.java
+++ b/src/main/java/com/influy/domain/answer/dto/AnswerResponseDto.java
@@ -18,6 +18,9 @@ public class AnswerResponseDto {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class AnswerTagListDto {
+
+        @Schema(description = "카테고리 이름", example = "색상")
+        private String category;
         @Schema(description = "태그 이름", example = "네이비")
         private String tag;
 

--- a/src/main/java/com/influy/domain/answer/dto/jpql/AnswerJPQLResult.java
+++ b/src/main/java/com/influy/domain/answer/dto/jpql/AnswerJPQLResult.java
@@ -13,4 +13,9 @@ public class AnswerJPQLResult {
         String getContent();
         LocalDateTime getCreatedAt();
     }
+
+    public interface UncheckedAnswer {
+        Long getItemId();
+        Integer getUncheckedCount();
+    }
 }

--- a/src/main/java/com/influy/domain/answer/entity/Answer.java
+++ b/src/main/java/com/influy/domain/answer/entity/Answer.java
@@ -32,4 +32,7 @@ public class Answer extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "question_id")
     private Question question;
+
+    @Builder.Default
+    private Boolean isChecked = false;
 }

--- a/src/main/java/com/influy/domain/answer/repository/AnswerRepository.java
+++ b/src/main/java/com/influy/domain/answer/repository/AnswerRepository.java
@@ -5,6 +5,7 @@ import com.influy.domain.answer.entity.Answer;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -25,4 +26,18 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
     """)
     List<Answer> findCommonAnswersByQuestionTagId(@Param("questionTagId") Long questionTagId);
 
+
+    @Query("""
+    SELECT q.item.id AS itemId,
+           SUM(CASE WHEN a.isChecked = false THEN 1 ELSE 0 END) AS uncheckedCount
+    FROM Question q
+    LEFT JOIN Answer a ON a.question = q
+    WHERE q.member.id = :memberId
+    GROUP BY q.item.id
+    """)
+    List<AnswerJPQLResult.UncheckedAnswer> findAllUnCheckedOfMemberQuestion(@Param("memberId") Long memberId);
+
+    @Modifying
+    @Query("UPDATE Answer a SET a.isChecked = true WHERE a.id IN :answerIds AND a.isChecked = false")
+    void setAnswersAsChecked(@Param("answerIds") List<Long> answerIds);
 }

--- a/src/main/java/com/influy/domain/answer/service/AnswerServiceImpl.java
+++ b/src/main/java/com/influy/domain/answer/service/AnswerServiceImpl.java
@@ -64,7 +64,10 @@ public class AnswerServiceImpl implements AnswerService {
         for (Answer answer : commonList) uniqueAnswers.putIfAbsent(answer.getContent(), answer);
         List<Answer> commonAnswerList = new ArrayList<>(uniqueAnswers.values());
         answerList.addAll(commonAnswerList);
-        return AnswerConverter.toAnswerTagListDto(questionTag, answerList);
+
+        //태그가 속한 카테고리 이름
+        String questionCategoryName = questionTag.getQuestionCategory().getName();
+        return AnswerConverter.toAnswerTagListDto(questionCategoryName, questionTag, answerList);
     }
 
     @Override

--- a/src/main/java/com/influy/domain/home/service/HomeServiceImpl.java
+++ b/src/main/java/com/influy/domain/home/service/HomeServiceImpl.java
@@ -86,7 +86,8 @@ public class HomeServiceImpl implements HomeService {
         Pageable pageable = pageRequestDto.toPageable();
 
         //아이템 조회(1순위 isChecked=false 많은 순, 2순위 pendingQuestions 많은 순)
-        Page<ItemJPQLResponse.ItemWithQuestionStatus> items = itemRepository.getItemsWithQuestionStatus(seller.getId(), pageable);
+        LocalDateTime now = LocalDateTime.now();
+        Page<ItemJPQLResponse.ItemWithQuestionStatus> items = itemRepository.getItemsWithQuestionStatus(seller.getId(), now, pageable);
         List<Long> itemIds = items.getContent().stream().map(item->item.getItem().getId()).toList();
 
         //현재 top3

--- a/src/main/java/com/influy/domain/item/dto/jpql/ItemJPQLResponse.java
+++ b/src/main/java/com/influy/domain/item/dto/jpql/ItemJPQLResponse.java
@@ -1,6 +1,8 @@
 package com.influy.domain.item.dto.jpql;
 
 import com.influy.domain.item.entity.Item;
+import com.influy.domain.member.entity.Member;
+import com.influy.domain.sellerProfile.entity.SellerProfile;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -17,5 +19,14 @@ public class ItemJPQLResponse {
         Item getItem();
         Long getNewQuestions();
         Long getPendingQuestions();
+    }
+
+    public interface  ItemWithSellerInfo{
+        Long getItemId();
+        String getItemTitle();
+        String getItemMainImg();
+        String getSellerNickname();
+        String getSellerProfileImg();
+
     }
 }

--- a/src/main/java/com/influy/domain/item/entity/Item.java
+++ b/src/main/java/com/influy/domain/item/entity/Item.java
@@ -39,11 +39,13 @@ public class Item extends BaseEntity {
 
     private String tagline;
 
-    @NotNull
     private LocalDateTime startDate;
 
-    @NotNull
     private LocalDateTime endDate;
+
+    @NotNull
+    @Builder.Default
+    private boolean isDateUndefined = true;
 
     @Builder.Default
     @Setter

--- a/src/main/java/com/influy/domain/item/entity/Item.java
+++ b/src/main/java/com/influy/domain/item/entity/Item.java
@@ -45,7 +45,7 @@ public class Item extends BaseEntity {
 
     @NotNull
     @Builder.Default
-    private boolean isDateUndefined = true;
+    private boolean isDateUndefined = false;
 
     @Builder.Default
     @Setter

--- a/src/main/java/com/influy/domain/item/repository/ItemRepository.java
+++ b/src/main/java/com/influy/domain/item/repository/ItemRepository.java
@@ -83,4 +83,13 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
     List<Item> findTop3BySellerId(Long sellerId);
 
     Boolean existsBySellerId(Long id);
+
+    @Query("""
+    SELECT i.id AS itemId, i.name AS itemTitle, i.mainImg AS itemMainImg, m.nickname AS sellerNickname, m.profileImg AS sellerProfileImg
+    FROM Item i
+    JOIN SellerProfile s ON i.seller = s
+    JOIN Member m ON s.member = m
+    WHERE i.id IN (:itemIds)
+    """)
+    List<ItemJPQLResponse.ItemWithSellerInfo> findAllWithSellerInfoById(@Param("itemIds") List<Long> itemIds);
 }

--- a/src/main/java/com/influy/domain/item/repository/ItemRepository.java
+++ b/src/main/java/com/influy/domain/item/repository/ItemRepository.java
@@ -70,7 +70,7 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
         SUM(CASE WHEN q.isAnswered = false THEN 1 ELSE 0 END) AS pendingQuestions
     FROM Item i
     LEFT JOIN Question q ON q.item = i
-    WHERE i.seller.id = :sellerId AND i.talkBoxOpenStatus = 'OPENED' AND i.endDate >= :now
+    WHERE i.seller.id = :sellerId AND i.talkBoxOpenStatus = 'OPENED' AND (i.endDate >= :now OR i.endDate IS NULL)
     GROUP BY i.id
     ORDER BY newQuestions DESC, pendingQuestions DESC
     """, countQuery = """

--- a/src/main/java/com/influy/domain/item/repository/ItemRepository.java
+++ b/src/main/java/com/influy/domain/item/repository/ItemRepository.java
@@ -70,7 +70,7 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
         SUM(CASE WHEN q.isAnswered = false THEN 1 ELSE 0 END) AS pendingQuestions
     FROM Item i
     LEFT JOIN Question q ON q.item = i
-    WHERE i.seller.id = :sellerId AND i.talkBoxOpenStatus = 'OPENED'
+    WHERE i.seller.id = :sellerId AND i.talkBoxOpenStatus = 'OPENED' AND i.endDate >= :now
     GROUP BY i.id
     ORDER BY newQuestions DESC, pendingQuestions DESC
     """, countQuery = """
@@ -78,7 +78,7 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
         FROM Item i
         WHERE i.seller.id = :sellerId
         """)
-    Page<ItemJPQLResponse.ItemWithQuestionStatus> getItemsWithQuestionStatus(@Param("sellerId") Long sellerId, Pageable pageable);
+    Page<ItemJPQLResponse.ItemWithQuestionStatus> getItemsWithQuestionStatus(@Param("sellerId") Long sellerId, @Param("now")LocalDateTime now, Pageable pageable);
 
     List<Item> findTop3BySellerId(Long sellerId);
 

--- a/src/main/java/com/influy/domain/member/dto/MemberRequestDTO.java
+++ b/src/main/java/com/influy/domain/member/dto/MemberRequestDTO.java
@@ -11,7 +11,7 @@ import java.util.List;
 public class MemberRequestDTO {
     @Getter
     public static class UserJoin {
-        @Schema(description = "멤버 고유 아이디", example = "@rapper_mj")
+        @Schema(description = "멤버 고유 아이디", example = "rapper_mj")
         private String username;
 
         @Schema(description = "멤버의 카카오 회원 번호", example = "1234567890")
@@ -37,7 +37,7 @@ public class MemberRequestDTO {
     }
     @Getter
     public static class UsernameDuplicateCheck{
-        @Schema(description = "유저네임", example = "@rapper_mj")
+        @Schema(description = "유저네임", example = "rapper_mj")
         private String username;
     }
 

--- a/src/main/java/com/influy/domain/question/controller/QuestionController.java
+++ b/src/main/java/com/influy/domain/question/controller/QuestionController.java
@@ -96,6 +96,7 @@ public class QuestionController {
 
         QuestionResponseDTO.UserViewQNAPage body = questionService.getQNAsOf(member.getId(),itemId,pageable);
 
+
         return ApiResponse.onSuccess(body);
     }
 
@@ -145,6 +146,18 @@ public class QuestionController {
                                                                  @PathVariable("questionCategoryId") Long questionCategoryId,
                                                                  @RequestBody @Valid QuestionRequestDTO.DeleteDto request) {
         return ApiResponse.onSuccess(questionService.delete(userDetails, itemId, questionCategoryId, request));
+    }
+
+    @GetMapping("/user/items/talkbox")
+    @Operation(summary = "유저가 아이템 별 톡박스 목록 조회", description = "아이템 별 톡박스")
+    public ApiResponse<QuestionResponseDTO.UserTalkBoxItemPageDTO> getUserTalkBoxItems(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                                                       @Valid @ParameterObject PageRequestDto pageDTO){
+
+        Member member = memberService.findById(userDetails.getId());
+
+        QuestionResponseDTO.UserTalkBoxItemPageDTO body = questionService.getUserTalkBoxItems(member,pageDTO);
+
+        return ApiResponse.onSuccess(body);
     }
 
 }

--- a/src/main/java/com/influy/domain/question/converter/QuestionConverter.java
+++ b/src/main/java/com/influy/domain/question/converter/QuestionConverter.java
@@ -18,9 +18,11 @@ import org.springframework.data.domain.Page;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class QuestionConverter {
 
@@ -90,18 +92,24 @@ public class QuestionConverter {
                 .build();
     }
 
-    public static QuestionResponseDTO.UserViewQNAPage toUserViewQNAPage(Page<AnswerJPQLResult.UserViewQNAInfo> userQNAList) {
-        List<QuestionResponseDTO.UserViewQNA> content = userQNAList != null ?
+    public static QuestionResponseDTO.UserViewQNAPage toUserViewQNAPage(Page<AnswerJPQLResult.UserViewQNAInfo> userQNAList,
+                                                                        String greeting) {
+        List<QuestionResponseDTO.UserViewQNA> content = new ArrayList<>(userQNAList != null ?
                 userQNAList.getContent().stream().map(
-                qna->{
-                    if(qna.getType().equals("Q")){
-                        return toUserViewDTO(qna);
-                    } else{
-                        return AnswerConverter.toUserViewDTO(qna);
-                    }
-                }
-        ).toList()
-                : Collections.emptyList();
+                        qna -> {
+                            if (qna.getType().equals("Q")) {
+                                return toUserViewDTO(qna);
+                            } else {
+                                return AnswerConverter.toUserViewDTO(qna);
+                            }
+                        }
+                ).toList()
+                : Collections.emptyList());
+
+        if(greeting!=null){
+            AnswerResponseDto.UserViewGreeting message = AnswerConverter.toUserViewGreetingDTO(greeting);
+            content.add(message);
+        }
 
         return QuestionResponseDTO.UserViewQNAPage.builder()
                 .chatList(content)

--- a/src/main/java/com/influy/domain/question/converter/QuestionConverter.java
+++ b/src/main/java/com/influy/domain/question/converter/QuestionConverter.java
@@ -4,6 +4,7 @@ import com.influy.domain.answer.converter.AnswerConverter;
 import com.influy.domain.answer.dto.jpql.AnswerJPQLResult;
 import com.influy.domain.answer.dto.AnswerResponseDto;
 import com.influy.domain.answer.entity.Answer;
+import com.influy.domain.item.dto.jpql.ItemJPQLResponse;
 import com.influy.domain.item.entity.Item;
 import com.influy.domain.member.entity.Member;
 import com.influy.domain.question.dto.QuestionResponseDTO;
@@ -11,6 +12,7 @@ import com.influy.domain.question.dto.jpql.QuestionJPQLResult;
 import com.influy.domain.question.entity.Question;
 import com.influy.domain.questionCategory.dto.jpql.CategoryJPQLResult;
 import com.influy.domain.questionTag.entity.QuestionTag;
+import com.influy.domain.sellerProfile.entity.SellerProfile;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.springframework.data.domain.Page;
 
@@ -156,6 +158,45 @@ public class QuestionConverter {
     public static QuestionResponseDTO.DeleteResultDto toDeleteResultDto(List<Long> questionList) {
         return QuestionResponseDTO.DeleteResultDto.builder()
                 .questionIdList(questionList)
+                .build();
+    }
+
+    public static QuestionResponseDTO.UserTalkBoxItemDTO toUserTalkBoxItemDTO(ItemJPQLResponse.ItemWithSellerInfo itemSeller,
+                                                                              String lastChatContent,
+                                                                              LocalDateTime lastChatTime,
+                                                                              Integer uncheckedCnt){
+
+        return QuestionResponseDTO.UserTalkBoxItemDTO.builder()
+                .itemId(itemSeller.getItemId())
+                .itemTitle(itemSeller.getItemTitle())
+                .itemMainPic(itemSeller.getItemMainImg())
+                .sellerNickname(itemSeller.getSellerNickname())
+                .sellerProfilePic(itemSeller.getSellerProfileImg())
+                .lastChatContent(lastChatContent)
+                .lastChatTime(lastChatTime)
+                .uncheckedCnt(uncheckedCnt)
+                .build();
+    }
+
+    public static QuestionResponseDTO.UserTalkBoxItemPageDTO toUserTalkBoxItemPageDTO(Page<QuestionJPQLResult.ItemWithRecentChat> recentChatPage,
+                                                                                      Map<Long,Integer> uncheckedCounts,
+                                                                                      Map<Long, ItemJPQLResponse.ItemWithSellerInfo> itemSellerInfos) {
+
+        List<QuestionResponseDTO.UserTalkBoxItemDTO> list = recentChatPage.getContent().stream()
+                .map(recentChat -> {
+                    Long itemId = recentChat.getItemId();
+                    ItemJPQLResponse.ItemWithSellerInfo itemSeller = itemSellerInfos.get(itemId);
+                    Integer uncheckedCnt = uncheckedCounts.get(itemId);
+
+                    return toUserTalkBoxItemDTO(itemSeller,recentChat.getContent(),recentChat.getCreatedAt(),uncheckedCnt);
+                }).toList();
+        return QuestionResponseDTO.UserTalkBoxItemPageDTO.builder()
+                .talkboxList(list)
+                .isFirst(recentChatPage.isFirst())
+                .isLast(recentChatPage.isLast())
+                .listSize(list.size())
+                .totalPage(recentChatPage.getTotalPages())
+                .totalElements(recentChatPage.getTotalElements())
                 .build();
     }
 }

--- a/src/main/java/com/influy/domain/question/converter/QuestionConverter.java
+++ b/src/main/java/com/influy/domain/question/converter/QuestionConverter.java
@@ -125,6 +125,7 @@ public class QuestionConverter {
             }
         }
         return QuestionResponseDTO.IsAnsweredCntDTO.builder()
+                .categoryName(isAnsweredCntList.getFirst().getCategoryName())
                 .waitingCnt(waitingCnt)
                 .completedCnt(completedCnt)
                 .build();

--- a/src/main/java/com/influy/domain/question/dto/QuestionResponseDTO.java
+++ b/src/main/java/com/influy/domain/question/dto/QuestionResponseDTO.java
@@ -115,6 +115,8 @@ public class QuestionResponseDTO {
     @AllArgsConstructor
     @NoArgsConstructor
     public static class IsAnsweredCntDTO {
+        @Schema(description = "카테고리 이름", example="색상")
+        private String categoryName;
         @Schema(description = "답변 대기 개수", example = "14")
         private Long waitingCnt;
         @Schema(description = "답변 완료 개수", example = "30")

--- a/src/main/java/com/influy/domain/question/dto/QuestionResponseDTO.java
+++ b/src/main/java/com/influy/domain/question/dto/QuestionResponseDTO.java
@@ -2,10 +2,8 @@ package com.influy.domain.question.dto;
 
 import com.influy.domain.answer.dto.AnswerResponseDto;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
+import org.springframework.cglib.core.Local;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -176,5 +174,46 @@ public class QuestionResponseDTO {
     public static class DeleteResultDto {
         @Schema(description = "삭제된 질문 id 리스트")
         private List<Long> questionIdList;
+    }
+
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UserTalkBoxItemDTO {
+        @Schema(description = "해당 톡박스 아이템 id", example="1")
+        private Long itemId;
+        @Schema(description = "해당 톡박스 아이템 이름", example="뿌링뿌링클")
+        private String itemTitle;
+        @Schema(description = "해당 톡박스 아이템 대표 사진", example="http:/amazon.s3~")
+        private String itemMainPic;
+        @Schema(description = "아이템 셀러 닉네임", example="소현소현")
+        private String sellerNickname;
+        @Schema(description = "셀러 프로필 사진", example="http://amazon.s3~")
+        private String sellerProfilePic;
+        @Schema(description = "가장 최근 대화 내역(답변/질문 구분 X)", example="환불 도와드리겠습니다")
+        private String lastChatContent;
+        @Schema(description = "가장 최근 채팅 시간", example="2025-02-04Z23:11:11")
+        private LocalDateTime lastChatTime;
+        @Schema(description = "확인하지 않은 대화 개수", example="2")
+        private Integer uncheckedCnt;
+    }
+
+    @Getter @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor(access=AccessLevel.PROTECTED)
+    public static class UserTalkBoxItemPageDTO{
+        private List<UserTalkBoxItemDTO> talkboxList;
+        @Schema(description = "리스트 사이즈", example = "10")
+        private Integer listSize;
+        @Schema(description = "총 페이지", example = "2")
+        private Integer totalPage;
+        @Schema(description = "전체 톡박스 개수", example = "30")
+        private Long totalElements;
+        @Schema(description = "지금 첫 페이지인지", example = "false")
+        private Boolean isFirst;
+        @Schema(description = "마지막 페이지인지", example = "false")
+        private Boolean isLast;
     }
 }

--- a/src/main/java/com/influy/domain/question/dto/jpql/QuestionJPQLResult.java
+++ b/src/main/java/com/influy/domain/question/dto/jpql/QuestionJPQLResult.java
@@ -1,5 +1,6 @@
 package com.influy.domain.question.dto.jpql;
 
+import java.time.LocalDateTime;
 import java.util.Date;
 
 public class QuestionJPQLResult {
@@ -19,5 +20,11 @@ public class QuestionJPQLResult {
         String getTagName();
         Long getTagId();
         Date getCreatedAt();
+    }
+
+    public interface ItemWithRecentChat {
+        Long getItemId();
+        String getContent();
+        LocalDateTime getCreatedAt();
     }
 }

--- a/src/main/java/com/influy/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/com/influy/domain/question/repository/QuestionRepository.java
@@ -122,6 +122,18 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
     WHERE q.member_id = :memberId AND q.item_id = :itemId
     
     ORDER BY createdAt DESC
+    """, countQuery = """
+        SELECT COUNT(*)
+        FROM (
+            SELECT q.id
+            FROM question q
+            WHERE q.member_id = :memberId and q.item_id = :itemId
+            UNION ALL
+            SELECT a.id
+            FROM answer a
+            JOIN question q ON a.question_id = q.id
+            WHERE q.member_id = :memberId AND q.item_id = :itemId
+        ) AS total
     """, nativeQuery = true)
     Page<AnswerJPQLResult.UserViewQNAInfo> findAllByMemberIdAndItemId(@Param("memberId") Long memberId, @Param("itemId") Long itemId, Pageable pageable);
 

--- a/src/main/java/com/influy/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/com/influy/domain/question/repository/QuestionRepository.java
@@ -112,7 +112,7 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
     FROM question q
     LEFT JOIN question_tag qt ON q.question_tag_id = qt.id
     LEFT JOIN question_category qc ON qt.question_category_id = qc.id
-    WHERE q.member_id = :memberId
+    WHERE q.member_id = :memberId AND q.item_id = :itemId
     
     UNION ALL
     
@@ -163,4 +163,27 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
         GROUP BY q.item.id, q.isAnswered
     """)
     List<TalkBoxInfoPairDto> countByItemIdAndIsAnswered(@Param("itemIdList")List<Long> itemIdList);
+
+    @Query(value = """
+    SELECT item_id AS itemId, content AS content, created_at AS createdAt
+    FROM (
+        SELECT
+            item_id, content, created_at,
+            ROW_NUMBER() OVER (PARTITION BY item_id ORDER BY created_at DESC) AS rn
+        FROM (
+            SELECT q.item_id, q.content, q.created_at
+            FROM question q
+            WHERE q.member_id = :memberId
+    
+            UNION ALL
+    
+            SELECT a.item_id, a.content, a.created_at
+            FROM answer a
+            JOIN question q ON q.id = a.question_id
+            WHERE q.member_id = :memberId
+        ) AS combined
+    ) AS ranked
+    WHERE rn = 1 ORDER BY createdAt DESC
+    """, nativeQuery = true)
+    Page<QuestionJPQLResult.ItemWithRecentChat> getRecentChatOfMemberGroupByItem(@Param("memberId") Long memberId, Pageable pageable);
 }

--- a/src/main/java/com/influy/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/com/influy/domain/question/repository/QuestionRepository.java
@@ -126,23 +126,13 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
     Page<AnswerJPQLResult.UserViewQNAInfo> findAllByMemberIdAndItemId(@Param("memberId") Long memberId, @Param("itemId") Long itemId, Pageable pageable);
 
     @Query("""
-        SELECT q.isAnswered AS isAnswered, COUNT(q) AS totalQuestions
+        SELECT qc.name AS categoryName, q.isAnswered AS isAnswered, COUNT(q) AS totalQuestions
         FROM Question q
         JOIN q.questionTag.questionCategory qc
         WHERE qc.id = :categoryId AND q.isHidden = false
         GROUP BY q.isAnswered
     """)
     List<CategoryJPQLResult.IsAnswered> countIsAnsweredByCategoryId(@Param("categoryId") Long categoryId);
-
-
-    //답변 완료/답변 대기 개수를 isAnswered 별로 구분하여 조회
-    @Query("""
-        SELECT q.isAnswered AS isAnswered, COUNT(q) AS totalQuestions
-        FROM Question q
-        WHERE q.item.id = :itemId
-        GROUP BY q.isAnswered
-    """)
-    List<CategoryJPQLResult.IsAnswered> countIsAnsweredByItemId(@Param("itemId") Long itemId);
 
 
     @Query("""

--- a/src/main/java/com/influy/domain/question/service/QuestionService.java
+++ b/src/main/java/com/influy/domain/question/service/QuestionService.java
@@ -33,4 +33,6 @@ public interface QuestionService {
     QuestionResponseDTO.DeleteResultDto delete(CustomUserDetails userDetails, Long itemId, Long questionCategoryId, QuestionRequestDTO.DeleteDto request);
 
     QuestionResponseDTO.SellerViewPage getSellerViewQuestionPage(Long questionTagId, Long questionCategoryId, SellerProfile seller, Boolean isAnswered, PageRequestDto pageable);
+
+    QuestionResponseDTO.UserTalkBoxItemPageDTO getUserTalkBoxItems(Member member, PageRequestDto pageRequestDto);
 }

--- a/src/main/java/com/influy/domain/question/service/QuestionServiceImpl.java
+++ b/src/main/java/com/influy/domain/question/service/QuestionServiceImpl.java
@@ -3,7 +3,10 @@ package com.influy.domain.question.service;
 import com.influy.domain.ai.service.AiService;
 import com.influy.domain.answer.dto.jpql.AnswerJPQLResult;
 import com.influy.domain.answer.entity.Answer;
+import com.influy.domain.answer.repository.AnswerRepository;
+import com.influy.domain.item.dto.jpql.ItemJPQLResponse;
 import com.influy.domain.item.entity.Item;
+import com.influy.domain.item.repository.ItemRepository;
 import com.influy.domain.member.entity.Member;
 import com.influy.domain.member.service.MemberService;
 import com.influy.domain.question.converter.QuestionConverter;
@@ -25,8 +28,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Service
@@ -36,6 +42,8 @@ public class QuestionServiceImpl implements QuestionService {
     private final QuestionRepository questionRepository;
     private final AiService aiService;
     private final MemberService memberService;
+    private final ItemRepository itemRepository;
+    private final AnswerRepository answerRepository;
 
 
     @Override
@@ -67,11 +75,22 @@ public class QuestionServiceImpl implements QuestionService {
 
 
     @Override
+    @Transactional
     public QuestionResponseDTO.UserViewQNAPage getQNAsOf(Long memberId, Long itemId, PageRequestDto pageableDto) {
 
         Pageable pageable = pageableDto.toPageable();
         //유저에게는 question 의 Hidden 상태와 무관하게 모두 보여줌
         Page<AnswerJPQLResult.UserViewQNAInfo> userQNAList= questionRepository.findAllByMemberIdAndItemId(memberId, itemId, pageable);
+
+        List<Long> answerIds = new ArrayList<>();
+        for(AnswerJPQLResult.UserViewQNAInfo qna : userQNAList.getContent()){
+            if(qna.getType().equals("A")){
+                answerIds.add(qna.getId());
+            }
+        }
+
+        //확인 처리
+        answerRepository.setAnswersAsChecked(answerIds);
 
         return QuestionConverter.toUserViewQNAPage(userQNAList);
     }
@@ -145,6 +164,36 @@ public class QuestionServiceImpl implements QuestionService {
 
         //응답 dto
         return QuestionConverter.toSellerViewPageDTO(questions, nthQuestions, newQuestions);
+    }
+
+    @Override
+    public QuestionResponseDTO.UserTalkBoxItemPageDTO getUserTalkBoxItems(Member member, PageRequestDto pageRequestDto) {
+
+        Pageable pageable = pageRequestDto.toPageable();
+        //아이템 별 최신 채팅 내용, 시간
+        Page<QuestionJPQLResult.ItemWithRecentChat> itemWithRecentChats = questionRepository.getRecentChatOfMemberGroupByItem(member.getId(), pageable);
+        List<Long> itemIds = itemWithRecentChats.getContent().stream().map(QuestionJPQLResult.ItemWithRecentChat::getItemId).toList();
+
+
+        //아이템별 해당 멤버가 확인 안한 답변 개수
+        List<AnswerJPQLResult.UncheckedAnswer> uncheckedList =answerRepository.findAllUnCheckedOfMemberQuestion(member.getId());
+        Map<Long, Integer> uncheckedMap = uncheckedList.stream()
+                .collect(Collectors.toMap(
+                        AnswerJPQLResult.UncheckedAnswer::getItemId,
+                        AnswerJPQLResult.UncheckedAnswer::getUncheckedCount
+                ));
+
+
+        //아이템 정보 + 셀러 정보
+        List<ItemJPQLResponse.ItemWithSellerInfo> itemAndSellerList = itemRepository.findAllWithSellerInfoById(itemIds);
+        Map<Long, ItemJPQLResponse.ItemWithSellerInfo> itemSellerMap =
+                itemAndSellerList.stream().collect(Collectors.toMap(
+                        ItemJPQLResponse.ItemWithSellerInfo::getItemId,
+                        Function.identity()
+                ));
+
+        return QuestionConverter.toUserTalkBoxItemPageDTO(itemWithRecentChats,uncheckedMap,itemSellerMap);
+
     }
 
 }

--- a/src/main/java/com/influy/domain/question/service/QuestionServiceImpl.java
+++ b/src/main/java/com/influy/domain/question/service/QuestionServiceImpl.java
@@ -91,8 +91,14 @@ public class QuestionServiceImpl implements QuestionService {
 
         //확인 처리
         answerRepository.setAnswersAsChecked(answerIds);
+        String greeting = null;
 
-        return QuestionConverter.toUserViewQNAPage(userQNAList);
+        if(userQNAList.isLast()){
+            Item item = itemRepository.findById(itemId).orElseThrow(()->new GeneralException(ErrorStatus.ITEM_NOT_FOUND));
+            greeting = item.getTalkBoxComment();
+        }
+
+        return QuestionConverter.toUserViewQNAPage(userQNAList, greeting);
     }
 
     @Override

--- a/src/main/java/com/influy/domain/questionCategory/controller/QuestionCategoryController.java
+++ b/src/main/java/com/influy/domain/questionCategory/controller/QuestionCategoryController.java
@@ -70,7 +70,7 @@ public class QuestionCategoryController {
         SellerProfile seller = memberService.checkSeller(userDetails);
         sellerService.checkQuestionOwner(null, categoryId, seller.getId());
 
-        List<CategoryJPQLResult.IsAnswered> isAnsweredCntList = questionCategoryService.getIsAnsweredMap(categoryId,null);
+        List<CategoryJPQLResult.IsAnswered> isAnsweredCntList = questionCategoryService.getIsAnsweredMap(categoryId);
         QuestionResponseDTO.IsAnsweredCntDTO body = QuestionConverter.toIsAnsweredCntDTO(isAnsweredCntList);
 
 

--- a/src/main/java/com/influy/domain/questionCategory/dto/jpql/CategoryJPQLResult.java
+++ b/src/main/java/com/influy/domain/questionCategory/dto/jpql/CategoryJPQLResult.java
@@ -10,6 +10,7 @@ public class CategoryJPQLResult {
     }
 
     public interface IsAnswered{
+        String getCategoryName();
         Boolean getIsAnswered();
         Long getTotalQuestions();
     }

--- a/src/main/java/com/influy/domain/questionCategory/service/QuestionCategoryService.java
+++ b/src/main/java/com/influy/domain/questionCategory/service/QuestionCategoryService.java
@@ -15,7 +15,7 @@ public interface QuestionCategoryService {
     List<String> generateCategory(CustomUserDetails userDetails, Long itemId);
     QuestionCategory findByCategoryIdAndItemId(Long questionCategoryId, Long itemId);
 
-    List<CategoryJPQLResult.IsAnswered> getIsAnsweredMap(Long categoryId, Long itemId);
+    List<CategoryJPQLResult.IsAnswered> getIsAnsweredMap(Long categoryId);
 
     QuestionCategoryResponseDto.ViewListDto getListUser(CustomUserDetails userDetails, Long itemId);
 }

--- a/src/main/java/com/influy/domain/questionCategory/service/QuestionCategoryServiceImpl.java
+++ b/src/main/java/com/influy/domain/questionCategory/service/QuestionCategoryServiceImpl.java
@@ -88,14 +88,10 @@ public class QuestionCategoryServiceImpl implements QuestionCategoryService{
     }
 
     @Override
-    public List<CategoryJPQLResult.IsAnswered> getIsAnsweredMap(Long categoryId, Long itemId) {
+    public List<CategoryJPQLResult.IsAnswered> getIsAnsweredMap(Long categoryId) {
 
-        if(categoryId!=null){
-            return questionRepository.countIsAnsweredByCategoryId(categoryId);
-        }else if(itemId!=null){
-            return questionRepository.countIsAnsweredByItemId(itemId);
-        }
-        return null;
+        return questionRepository.countIsAnsweredByCategoryId(categoryId);
+
     }
 
     @Override

--- a/src/main/java/com/influy/domain/questionTag/repository/QuestionTagRepository.java
+++ b/src/main/java/com/influy/domain/questionTag/repository/QuestionTagRepository.java
@@ -20,7 +20,7 @@ public interface QuestionTagRepository extends JpaRepository<QuestionTag, Long> 
           AND qt.questionCategory.id = :questionCategoryId
           AND qt.questionCategory.item.id = :itemId
     """)
-    Optional<QuestionTag> findValidQuestionTag(Long itemId, Long questionCategoryId, Long questionTagId);
+    Optional<QuestionTag> findValidQuestionTag(@Param("itemId") Long itemId, @Param(("questionCategoryId")) Long questionCategoryId, @Param("questionTagId") Long questionTagId);
 
     //태그 id, 이름, 태그에 속한 isAnswered 상태 질문 개수, 새 질문 개수
     @Query(value = """


### PR DESCRIPTION
## 💜 Related Issue

> #66

## 💜 Work Details

- [x] 유저가 톡박스 리스트 조회
- [x] 셀러 홈에서 마감 지난 상품 톡박스 현황 조회 안하게 변경
- [x] 프론트 요청으로 일부 api에서 카테고리 이름도 함께 제공

## 💜 Review Requirement

> 유저가 톡박스 조회
answer 엔티티에 isChecked 추가함

> 프론트 요청으로  **1. 카테고리 별 응답/미응답 개수 조회 시 2. 해당 태그의 이전 답변 리스트 조회 시** 카테고리 이름을 함께 전달합니다.
