### PR TITLE
#64 Refactor: 아이템 조회 관련 수정

### DIFF
--- a/src/main/java/com/influy/domain/image/service/ImageService.java
+++ b/src/main/java/com/influy/domain/image/service/ImageService.java
@@ -2,10 +2,13 @@ package com.influy.domain.image.service;
 
 import com.influy.domain.image.dto.ImageRequestDto;
 import com.influy.domain.image.dto.ImageResponseDto;
+import com.influy.domain.item.entity.Item;
 import com.influy.global.jwt.CustomUserDetails;
 
 import java.net.URL;
+import java.util.List;
 
 public interface ImageService {
     ImageResponseDto.UploadResultDto uploadImg(CustomUserDetails userDetails, ImageRequestDto.UploadDto request);
+//    void deleteItemImg(Item item);
 }

--- a/src/main/java/com/influy/domain/image/service/ImageService.java
+++ b/src/main/java/com/influy/domain/image/service/ImageService.java
@@ -10,5 +10,4 @@ import java.util.List;
 
 public interface ImageService {
     ImageResponseDto.UploadResultDto uploadImg(CustomUserDetails userDetails, ImageRequestDto.UploadDto request);
-//    void deleteItemImg(Item item);
 }

--- a/src/main/java/com/influy/domain/image/service/ImageServiceImpl.java
+++ b/src/main/java/com/influy/domain/image/service/ImageServiceImpl.java
@@ -3,16 +3,19 @@ package com.influy.domain.image.service;
 import com.influy.domain.image.converter.ImageConverter;
 import com.influy.domain.image.dto.ImageRequestDto;
 import com.influy.domain.image.dto.ImageResponseDto;
+import com.influy.domain.item.entity.Item;
 import com.influy.global.jwt.CustomUserDetails;
 import org.springframework.beans.factory.annotation.Value;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -33,7 +36,7 @@ public class ImageServiceImpl implements ImageService {
         String baseName = original.substring(0, original.lastIndexOf('.')); // influy
         String extension = original.substring(original.lastIndexOf('.') + 1); // png
 
-        String fullPath = "image-src/" + UUID.randomUUID() + "-" + baseName + "." + extension; // image-src/123e4567-influy.png
+        String fullPath = "image-src/user-" + userDetails.getId() + "/" + UUID.randomUUID() + "-" + baseName + "." + extension; // image-src/user-1/123e4567-influy.png
 
         PutObjectRequest objectRequest = ImageConverter.toPutObjectRequest(bucket, fullPath, extension);
         PutObjectPresignRequest presignRequest = ImageConverter.toPutObjectPresignRequest(objectRequest);
@@ -43,4 +46,22 @@ public class ImageServiceImpl implements ImageService {
 
         return ImageConverter.toUploadResultDto(presignedRequest.url(), imageUrl);
     }
+
+//    @Override
+//    @Transactional
+//    public void deleteItemImg(Item item) {
+//        String keyPrefix = "https://" + bucket + ".s3." + region + ".amazonaws.com/";
+//        List<String> imageList = item.getImageList();
+//        for (String img: imageList) {
+//            String imageKey = img.replace(keyPrefix, "");
+//
+//            DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
+//                    .bucket(bucket)
+//                    .key(imageKey)
+//                    .build();
+//
+//            s3Client.deleteObject(deleteRequest);
+//        }
+//
+//    }
 }

--- a/src/main/java/com/influy/domain/image/service/ImageServiceImpl.java
+++ b/src/main/java/com/influy/domain/image/service/ImageServiceImpl.java
@@ -46,22 +46,4 @@ public class ImageServiceImpl implements ImageService {
 
         return ImageConverter.toUploadResultDto(presignedRequest.url(), imageUrl);
     }
-
-//    @Override
-//    @Transactional
-//    public void deleteItemImg(Item item) {
-//        String keyPrefix = "https://" + bucket + ".s3." + region + ".amazonaws.com/";
-//        List<String> imageList = item.getImageList();
-//        for (String img: imageList) {
-//            String imageKey = img.replace(keyPrefix, "");
-//
-//            DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
-//                    .bucket(bucket)
-//                    .key(imageKey)
-//                    .build();
-//
-//            s3Client.deleteObject(deleteRequest);
-//        }
-//
-//    }
 }

--- a/src/main/java/com/influy/domain/item/controller/ItemRestController.java
+++ b/src/main/java/com/influy/domain/item/controller/ItemRestController.java
@@ -25,7 +25,6 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class ItemRestController {
     private final ItemService itemService;
-    private final MemberService memberService;
 
     @PostMapping("/seller/items")
     @Operation(summary = "셀러 상품 상세정보 작성 후 생성")

--- a/src/main/java/com/influy/domain/item/controller/ItemRestController.java
+++ b/src/main/java/com/influy/domain/item/controller/ItemRestController.java
@@ -6,7 +6,6 @@ import com.influy.domain.item.dto.ItemResponseDto;
 import com.influy.domain.item.entity.Item;
 import com.influy.domain.item.entity.TalkBoxOpenStatus;
 import com.influy.domain.item.service.ItemService;
-import com.influy.domain.member.service.MemberService;
 import com.influy.domain.sellerProfile.entity.ItemSortType;
 import com.influy.global.apiPayload.ApiResponse;
 import com.influy.global.common.PageRequestDto;

--- a/src/main/java/com/influy/domain/item/controller/ItemRestController.java
+++ b/src/main/java/com/influy/domain/item/controller/ItemRestController.java
@@ -8,7 +8,6 @@ import com.influy.domain.item.entity.TalkBoxOpenStatus;
 import com.influy.domain.item.service.ItemService;
 import com.influy.domain.member.service.MemberService;
 import com.influy.domain.sellerProfile.entity.ItemSortType;
-import com.influy.domain.sellerProfile.entity.SellerProfile;
 import com.influy.global.apiPayload.ApiResponse;
 import com.influy.global.common.PageRequestDto;
 import com.influy.global.jwt.CustomUserDetails;
@@ -100,7 +99,7 @@ public class ItemRestController {
     }
 
     @GetMapping("/seller/{sellerId}/items/{itemId}/item-overview")
-    @Operation(summary = "아이템 간략 정보 조회 [대표사진, 이름, 태그라인")
+    @Operation(summary = "아이템 간략 정보 조회 [ 대표사진, 이름, 태그라인 ]")
     public ApiResponse<ItemResponseDto.ItemOverviewDto> getItemInfo(@PathVariable("sellerId") Long sellerId,
                                                                    @PathVariable("itemId") Long itemId) {
         return ApiResponse.onSuccess(itemService.getItemOverview(sellerId, itemId));

--- a/src/main/java/com/influy/domain/item/converter/ItemConverter.java
+++ b/src/main/java/com/influy/domain/item/converter/ItemConverter.java
@@ -30,6 +30,8 @@ public class ItemConverter {
                 .marketLink(request.getMarketLink())
                 .comment(request.getComment())
                 .isArchived(request.getIsArchived())
+                .itemStatus(request.getStatus())
+                .isDateUndefined(request.getIsDateUndefined())
                 .build();
     }
 
@@ -59,6 +61,7 @@ public class ItemConverter {
                 .currentStatus(item.getItemStatus())
                 .liked(liked)
                 .talkBoxInfo(memberRole==MemberRole.SELLER ? toTalkBoxInfoDto(item, waitingCnt, completedCnt):null)
+                .isDateUndefined(item.getIsDateUndefined())
                 .build();
     }
 
@@ -99,8 +102,8 @@ public class ItemConverter {
     public static ItemResponseDto.DetailViewDto toDetailViewDto(Item item) {
         List<String> itemImgLinkList = item.getImageList();
 
-        List<String> itemCategoryList = item.getItemCategoryList().stream()
-                .map(ic -> ic.getCategory().getCategory())
+        List<Long> itemCategoryList = item.getItemCategoryList().stream()
+                .map(ic -> ic.getCategory().getId())
                 .toList();
 
         return ItemResponseDto.DetailViewDto.builder()
@@ -117,6 +120,7 @@ public class ItemConverter {
                 .salePrice(item.getSalePrice())
                 .itemImgList(itemImgLinkList)
                 .itemCategoryList(itemCategoryList)
+                .isDateUndefined(item.getIsDateUndefined())
                 .build();
     }
 

--- a/src/main/java/com/influy/domain/item/dto/ItemRequestDto.java
+++ b/src/main/java/com/influy/domain/item/dto/ItemRequestDto.java
@@ -3,10 +3,7 @@ package com.influy.domain.item.dto;
 import com.influy.domain.item.entity.ItemStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Size;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -21,7 +18,7 @@ public class ItemRequestDto {
         @Schema(description = "아이템 제목", example = "제작 원피스")
         private String name;
 
-        @Schema(description = "아이템 카테고리, 1~3개", example = "[\"1\", \"2\"]")
+        @Schema(description = "아이템 카테고리, 1~3개", example = "[1, 2]")
         @Size(max = 3, message = "카테고리는 최대 3개까지만 업로드할 수 있습니다.")
         private List<Long> itemCategoryIdList;
 
@@ -51,6 +48,12 @@ public class ItemRequestDto {
 
         @Schema(description = "보관 여부 (보관: true, 게시: false)", example = "false")
         private Boolean isArchived;
+
+        @Schema(description = "아이템 표기 상태", example = "SOLD_OUT")
+        private ItemStatus status;
+
+        @Schema(description = "기간 기입 여부", example = "false")
+        private Boolean isDateUndefined;
     }
 
     @Getter

--- a/src/main/java/com/influy/domain/item/dto/ItemResponseDto.java
+++ b/src/main/java/com/influy/domain/item/dto/ItemResponseDto.java
@@ -64,6 +64,9 @@ public class ItemResponseDto {
 
         @Schema(description = "셀러일 경우 톡박스 관련 정보")
         private TalkBoxInfoDto talkBoxInfo;
+
+        @Schema(description = "기간 기입 여부", example = "false")
+        private Boolean isDateUndefined;
     }
 
     @Getter
@@ -142,8 +145,11 @@ public class ItemResponseDto {
         @Schema(description = "아이템 사진 리스트, 대표사진은 리스트 맨 처음 순서로", example = "[xxx.png, xxxxx.png, xxxxxx.png]")
         private List<String> itemImgList;
 
-        @Schema(description = "아이템 카테고리, 1~3개", example = "[뷰티, 패션, 소품]")
-        private List<String> itemCategoryList;
+        @Schema(description = "아이템 카테고리, 1~3개", example = "[1, 2, 3]")
+        private List<Long> itemCategoryList;
+
+        @Schema(description = "기간 기입 여부", example = "false")
+        private Boolean isDateUndefined;
     }
 
     @Getter

--- a/src/main/java/com/influy/domain/item/entity/Item.java
+++ b/src/main/java/com/influy/domain/item/entity/Item.java
@@ -33,16 +33,17 @@ public class Item extends BaseEntity {
     @NotBlank
     private String name;
 
-    private Long regularPrice;
+    @Builder.Default
+    private Long regularPrice = 0L;
 
-    private Long salePrice;
+    @Builder.Default
+    private Long salePrice = 0L;
 
-    private String tagline;
+    @Builder.Default
+    private String tagline = "";
 
-    @NotNull
     private LocalDateTime startDate;
 
-    @NotNull
     private LocalDateTime endDate;
 
     @Builder.Default
@@ -61,10 +62,11 @@ public class Item extends BaseEntity {
     @Setter
     private ItemStatus itemStatus = ItemStatus.DEFAULT;  //표기 상태: [기본, 연장, 완판]
 
-    @NotBlank
-    private String marketLink;
+    @Builder.Default
+    private String marketLink = "";
 
-    private String comment;
+    @Builder.Default
+    private String comment = "";
 
     @Builder.Default
     @Setter
@@ -84,6 +86,10 @@ public class Item extends BaseEntity {
     @Builder.Default
     @Setter
     private String mainImg = "";
+
+    @NotNull
+    @Builder.Default
+    private Boolean isDateUndefined = false;
 
     @Builder.Default
     @Enumerated(EnumType.STRING)
@@ -114,10 +120,9 @@ public class Item extends BaseEntity {
     private List<Like> likeList = new ArrayList<>();
 
     public void updateItem (String name, LocalDateTime startDate, LocalDateTime endDate, String tagline,
-                            Long regularPrice, Long salePrice, String marketLink, Integer itemPeriod, String comment, Boolean isArchived) {
+                            Long regularPrice, Long salePrice, String marketLink, Integer itemPeriod, String comment, Boolean isArchived,
+                            ItemStatus itemStatus, Boolean isDateUndefined) {
         this.name = name != null ? name : this.name;
-        this.startDate = startDate != null ? startDate : this.startDate;
-        this.endDate = endDate != null ? endDate : this.endDate;
         this.tagline = tagline != null ? tagline : this.tagline;
         this.regularPrice = regularPrice != null ? regularPrice : this.regularPrice;
         this.salePrice = salePrice != null ? salePrice : this.salePrice;
@@ -125,5 +130,17 @@ public class Item extends BaseEntity {
         this.itemPeriod = itemPeriod != null ? itemPeriod : this.itemPeriod;
         this.comment = comment != null ? comment : this.comment;
         this.isArchived = isArchived != null ? isArchived : this.isArchived;
+        this.itemStatus = itemStatus != null ? itemStatus : this.itemStatus;
+        this.isDateUndefined = isDateUndefined != null ? isDateUndefined : this.isDateUndefined;
+
+        if (this.isDateUndefined) {
+            // 기간 설정을 했다가 지웠거나 아예 안 한경우 -> startDate, endDate을 null로 저장
+            this.startDate = null;
+            this.endDate = null;
+        } else {
+            // 기간 설정 되어있는 것을 수정하거나 새로 정하거나 아예 수정하지 않은 경우 -> startDate, endDate 값 있으면 넣고 아니면 null로 저장
+            this.startDate = startDate != null ? startDate : this.startDate;
+            this.endDate = endDate != null ? endDate : this.endDate;
+        }
     }
 }

--- a/src/main/java/com/influy/domain/item/entity/Item.java
+++ b/src/main/java/com/influy/domain/item/entity/Item.java
@@ -7,6 +7,8 @@ import com.influy.domain.like.entity.Like;
 import com.influy.domain.question.entity.Question;
 import com.influy.domain.questionCategory.entity.QuestionCategory;
 import com.influy.domain.sellerProfile.entity.SellerProfile;
+import com.influy.global.apiPayload.code.status.ErrorStatus;
+import com.influy.global.apiPayload.exception.GeneralException;
 import com.influy.global.common.BaseEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
@@ -134,9 +136,11 @@ public class Item extends BaseEntity {
         this.isDateUndefined = isDateUndefined != null ? isDateUndefined : this.isDateUndefined;
 
         if (this.isDateUndefined) {
+            if (!this.isArchived) throw new GeneralException(ErrorStatus.ITEM_INFO_REQUIRED);
             // 기간 설정을 했다가 지웠거나 아예 안 한경우 -> startDate, endDate을 null로 저장
             this.startDate = null;
             this.endDate = null;
+
         } else {
             // 기간 설정 되어있는 것을 수정하거나 새로 정하거나 아예 수정하지 않은 경우 -> startDate, endDate 값 있으면 넣고 아니면 null로 저장
             this.startDate = startDate != null ? startDate : this.startDate;

--- a/src/main/java/com/influy/domain/item/entity/Item.java
+++ b/src/main/java/com/influy/domain/item/entity/Item.java
@@ -50,9 +50,6 @@ public class Item extends BaseEntity {
 
     @NotNull
     @Builder.Default
-    private boolean isDateUndefined = false;
-
-    @Builder.Default
     private Boolean isDateUndefined = false;
 
     @Builder.Default
@@ -95,10 +92,6 @@ public class Item extends BaseEntity {
     @Builder.Default
     @Setter
     private String mainImg = "";
-
-    @NotNull
-    @Builder.Default
-    private Boolean isDateUndefined = false;
 
     @Builder.Default
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/influy/domain/item/repository/ItemRepository.java
+++ b/src/main/java/com/influy/domain/item/repository/ItemRepository.java
@@ -9,7 +9,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.security.core.parameters.P;
 
 import java.time.LocalDateTime;
 import java.util.List;

--- a/src/main/java/com/influy/domain/item/repository/ItemRepository.java
+++ b/src/main/java/com/influy/domain/item/repository/ItemRepository.java
@@ -17,11 +17,6 @@ import java.util.List;
 public interface ItemRepository extends JpaRepository<Item, Long> {
     Integer countBySellerIdAndIsArchivedTrue(Long sellerId);
     Integer countBySellerIdAndIsArchivedFalse(Long sellerId);
-    Page<Item> findBySellerIdAndIsArchivedTrue(Long sellerId, Pageable pageable);
-
-    @Query("SELECT i FROM Item i WHERE i.seller.id = :sellerId AND i.isArchived = false AND i.endDate > :now")
-    Page<Item> findOngoingItems(@Param("sellerId")Long sellerId, @Param("now")LocalDateTime now, Pageable pageable);
-
     @Query("SELECT p.isArchived AS isArchived, COUNT(p) AS count FROM Item p WHERE p.seller.id = :sellerId GROUP BY p.isArchived")
     List<ItemJPQLResponse.IsArchivedItemCount> countBySellerIdGroupByIsArchived(@Param("sellerId") Long sellerId);
 
@@ -85,7 +80,7 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
 
     @Query("""
     SELECT i FROM Item i
-    WHERE i.seller.id = :sellerId AND i.isArchived = false
+    WHERE i.seller.id = :sellerId AND i.isArchived = :isArchived
     ORDER BY
       CASE
         WHEN i.endDate IS NULL THEN 2
@@ -94,11 +89,11 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
       END,
       i.endDate ASC
     """)
-    Page<Item> findAllSortedByEndDate(@Param("sellerId") Long sellerId, @Param("now") LocalDateTime now, Pageable pageable);
+    Page<Item> findAllSortedByEndDate(@Param("sellerId") Long sellerId, @Param("now") LocalDateTime now, @Param("isArchived") Boolean isArchived, Pageable pageable);
 
     @Query("""
     SELECT i FROM Item i
-    WHERE i.seller.id = :sellerId AND i.isArchived = false
+    WHERE i.seller.id = :sellerId AND i.isArchived = :isArchived
     ORDER BY
       CASE
         WHEN i.endDate IS NULL THEN 2
@@ -107,5 +102,23 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
       END,
       i.createdAt DESC
     """)
-    Page<Item> findAllSortedByCreatedAt(@Param("sellerId") Long sellerId, @Param("now") LocalDateTime now, Pageable pageable);
+    Page<Item> findAllSortedByCreatedAt(@Param("sellerId") Long sellerId, @Param("now") LocalDateTime now, @Param("isArchived") Boolean isArchived, Pageable pageable);
+
+    @Query("""
+    SELECT i FROM Item i
+    WHERE i.seller.id = :sellerId AND i.isArchived = :isArchived AND (i.endDate IS NULL OR i.endDate > :now)
+    ORDER BY
+      CASE
+        WHEN i.endDate IS NULL THEN 2
+        ELSE 1
+      END,
+      i.endDate ASC
+    """)
+    Page<Item> findOngoingItemsSortedByEndDate(@Param("sellerId") Long sellerId, @Param("now") LocalDateTime now, @Param("isArchived") Boolean isArchived, Pageable pageable);
+
+    @Query("""
+    SELECT i FROM Item i
+    WHERE i.seller.id = :sellerId AND i.isArchived = :isArchived AND (i.endDate IS NULL OR i.endDate > :now)
+    """)
+    Page<Item> findOngoingItemsSortedByCreatedAt(@Param("sellerId") Long sellerId, @Param("now") LocalDateTime now, @Param("isArchived") Boolean isArchived, Pageable pageable);
 }

--- a/src/main/java/com/influy/domain/item/repository/ItemRepository.java
+++ b/src/main/java/com/influy/domain/item/repository/ItemRepository.java
@@ -18,7 +18,6 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
     Integer countBySellerIdAndIsArchivedTrue(Long sellerId);
     Integer countBySellerIdAndIsArchivedFalse(Long sellerId);
     Page<Item> findBySellerIdAndIsArchivedTrue(Long sellerId, Pageable pageable);
-    Page<Item> findBySellerIdAndIsArchivedFalse(Long sellerId, Pageable pageable);
 
     @Query("SELECT i FROM Item i WHERE i.seller.id = :sellerId AND i.isArchived = false AND i.endDate > :now")
     Page<Item> findOngoingItems(@Param("sellerId")Long sellerId, @Param("now")LocalDateTime now, Pageable pageable);
@@ -83,4 +82,30 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
     List<Item> findTop3BySellerId(Long sellerId);
 
     Boolean existsBySellerId(Long id);
+
+    @Query("""
+    SELECT i FROM Item i
+    WHERE i.seller.id = :sellerId AND i.isArchived = false
+    ORDER BY
+      CASE
+        WHEN i.endDate IS NULL THEN 2
+        WHEN i.endDate <= :now THEN 3
+        ELSE 1
+      END,
+      i.endDate ASC
+    """)
+    Page<Item> findAllSortedByEndDate(@Param("sellerId") Long sellerId, @Param("now") LocalDateTime now, Pageable pageable);
+
+    @Query("""
+    SELECT i FROM Item i
+    WHERE i.seller.id = :sellerId AND i.isArchived = false
+    ORDER BY
+      CASE
+        WHEN i.endDate IS NULL THEN 2
+        WHEN i.endDate <= :now THEN 3
+        ELSE 1
+      END,
+      i.createdAt DESC
+    """)
+    Page<Item> findAllSortedByCreatedAt(@Param("sellerId") Long sellerId, @Param("now") LocalDateTime now, Pageable pageable);
 }

--- a/src/main/java/com/influy/domain/item/repository/ItemRepository.java
+++ b/src/main/java/com/influy/domain/item/repository/ItemRepository.java
@@ -31,7 +31,7 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
         SELECT i
         FROM Item i
         LEFT JOIN i.questionList q
-        WHERE i.endDate > :now
+        WHERE i.endDate IS NULL OR i.endDate > :now
         AND i.itemStatus != 'SOLD_OUT'
         AND i.seller.isPublic = true
         GROUP BY i
@@ -42,14 +42,15 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
     @Query("""
         SELECT ic.item FROM ItemCategory ic
         WHERE ic.category.id = :categoryId
-          AND ic.item.endDate > :now
+          AND ic.item.endDate IS NULL OR ic.item.endDate > :now
           AND ic.item.itemStatus != 'SOLD_OUT'
           AND ic.item.seller.isPublic = true
+          AND ic.item.isArchived = false
           ORDER BY ic.item.createdAt DESC
     """)
     Page<Item> findAllByCategoryId(@Param("categoryId") Long categoryId, Pageable pageable, @Param("now") LocalDateTime now);
 
-    @Query("SELECT i FROM Item i WHERE i.endDate > :now AND i.itemStatus != 'SOLD_OUT' AND i.seller.isPublic = true")
+    @Query("SELECT i FROM Item i WHERE (i.endDate IS NULL OR i.endDate > :now) AND i.itemStatus != 'SOLD_OUT' AND i.seller.isPublic = true AND i.isArchived = false ORDER BY CASE WHEN i.endDate IS NULL THEN 2 ELSE 1 END, i.endDate ASC")
     Page<Item> findAllNow(Pageable pageable, @Param("now") LocalDateTime now);
 
     Boolean existsByNameContaining(String query);

--- a/src/main/java/com/influy/domain/item/service/ItemService.java
+++ b/src/main/java/com/influy/domain/item/service/ItemService.java
@@ -1,24 +1,15 @@
 package com.influy.domain.item.service;
 
-import com.influy.domain.answer.dto.AnswerResponseDto;
-import com.influy.domain.faqCard.dto.FaqCardResponseDto;
 import com.influy.domain.item.dto.ItemRequestDto;
 import com.influy.domain.item.dto.ItemResponseDto;
 import com.influy.domain.item.entity.Item;
 import com.influy.domain.item.entity.TalkBoxInfoPair;
 import com.influy.domain.item.entity.TalkBoxOpenStatus;
-import com.influy.domain.member.entity.Member;
 import com.influy.domain.sellerProfile.entity.ItemSortType;
-import com.influy.domain.sellerProfile.entity.SellerProfile;
-import com.influy.global.apiPayload.code.status.SuccessStatus;
 import com.influy.global.common.PageRequestDto;
 import com.influy.global.jwt.CustomUserDetails;
-import jakarta.validation.Valid;
-import org.springframework.data.domain.Page;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface ItemService {
     Item create(CustomUserDetails userDetails, ItemRequestDto.DetailDto request);

--- a/src/main/java/com/influy/domain/item/service/ItemServiceImpl.java
+++ b/src/main/java/com/influy/domain/item/service/ItemServiceImpl.java
@@ -112,7 +112,6 @@ public class ItemServiceImpl implements ItemService {
                 request.getStatus(), request.getIsDateUndefined());
 
         if (request.getItemImgList() != null) {
-//            imageService.deleteItemImg(item);
             item.getImageList().clear();
             createItemImgList(request, item);
         }

--- a/src/main/java/com/influy/domain/item/service/ItemServiceImpl.java
+++ b/src/main/java/com/influy/domain/item/service/ItemServiceImpl.java
@@ -2,6 +2,7 @@ package com.influy.domain.item.service;
 
 import com.influy.domain.category.entity.Category;
 import com.influy.domain.category.repository.CategoryRepository;
+import com.influy.domain.image.service.ImageService;
 import com.influy.domain.item.converter.ItemConverter;
 import com.influy.domain.item.dto.ItemRequestDto;
 import com.influy.domain.item.dto.ItemResponseDto;
@@ -53,6 +54,7 @@ public class ItemServiceImpl implements ItemService {
     private final MemberService memberService;
     private final QuestionRepository questionRepository;
     private final LikeRepository likeRepository;
+    private final ImageService imageService;
 
     @Override
     @Transactional
@@ -66,10 +68,9 @@ public class ItemServiceImpl implements ItemService {
         Item item = ItemConverter.toItem(seller, request);
         item = itemRepository.save(item);
 
-        if (!request.getIsArchived()) {
-            createItemImgList(request, item);
-            createItemCategoryList(request, item);
-        }
+
+        if (!request.getItemImgList().isEmpty()) createItemImgList(request, item);
+        if (!request.getItemCategoryIdList().isEmpty())    createItemCategoryList(request, item);
 
         seller.getItemList().add(item);
 
@@ -111,6 +112,7 @@ public class ItemServiceImpl implements ItemService {
                 request.getStatus(), request.getIsDateUndefined());
 
         if (request.getItemImgList() != null) {
+//            imageService.deleteItemImg(item);
             item.getImageList().clear();
             createItemImgList(request, item);
         }

--- a/src/main/java/com/influy/domain/item/service/ItemServiceImpl.java
+++ b/src/main/java/com/influy/domain/item/service/ItemServiceImpl.java
@@ -58,11 +58,18 @@ public class ItemServiceImpl implements ItemService {
     @Transactional
     public Item create(CustomUserDetails userDetails, ItemRequestDto.DetailDto request) {
         SellerProfile seller = memberService.checkSeller(userDetails);
+        if (!request.getIsArchived() && (request.getItemImgList() == null || request.getIsDateUndefined() || request.getItemCategoryIdList() == null)) {
+            // 아이템 게시할때 필수 필드: 사진, 제목(게시, 보관 공통), 기간 (undefined=false여야함), 아이템 카테고리
+                throw new GeneralException(ErrorStatus.ITEM_INFO_REQUIRED);
+        }
+
         Item item = ItemConverter.toItem(seller, request);
         item = itemRepository.save(item);
 
-        createItemImgList(request, item);
-        createItemCategoryList(request, item);
+        if (!request.getIsArchived()) {
+            createItemImgList(request, item);
+            createItemCategoryList(request, item);
+        }
 
         seller.getItemList().add(item);
 
@@ -100,7 +107,10 @@ public class ItemServiceImpl implements ItemService {
                 .orElseThrow(() -> new GeneralException(ErrorStatus.ITEM_NOT_FOUND));
 
         item.updateItem(request.getName(), request.getStartDate(), request.getEndDate(), request.getTagline(),
-                request.getRegularPrice(), request.getSalePrice(), request.getMarketLink() , request.getItemPeriod(), request.getComment(), request.getIsArchived());
+                request.getRegularPrice(), request.getSalePrice(), request.getMarketLink() , request.getItemPeriod(), request.getComment(), request.getIsArchived(),
+                request.getStatus(), request.getIsDateUndefined());
+
+        if (!request.getIsArchived() && request.getIsDateUndefined()) throw new GeneralException(ErrorStatus.ITEM_INFO_REQUIRED);
 
         if (request.getItemImgList() != null) {
             item.getImageList().clear();
@@ -158,7 +168,6 @@ public class ItemServiceImpl implements ItemService {
         MemberRole memberRole = MemberRole.SELLER;
         List<Long> likeItems = new ArrayList<>();
 
-
         if (userDetails != null) {
             Member member = memberRepository.findById(userDetails.getId())
                     .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
@@ -188,12 +197,17 @@ public class ItemServiceImpl implements ItemService {
             itemPage = itemRepository.findOngoingItems(sellerId, LocalDateTime.now(), pageable);
         } else if (!isArchived & !isOnGoing) {
             // 보관 상품 아닌 것 중에서 진행 중 상품 필터 미적용
-            itemPage = itemRepository.findBySellerIdAndIsArchivedFalse(sellerId, pageable);
-        } else if (isArchived) {
+            if (sortType == ItemSortType.END_DATE) {
+                // 마감일 빠른 순 -> endDate = null -> endDate < now
+                itemPage = itemRepository.findAllSortedByEndDate(sellerId, LocalDateTime.now(), pageable);
+            } else {
+                // sortType == ItemSortType.CREATE_DATE
+                // 최신 생성 순 -> endDate = null -> endDate < now
+                itemPage = itemRepository.findAllSortedByCreatedAt(sellerId, LocalDateTime.now(), pageable);
+            }
+        } else {
             // 보관 상품
             itemPage = itemRepository.findBySellerIdAndIsArchivedTrue(sellerId, pageable);
-        } else {
-            throw new GeneralException(ErrorStatus.UNSUPPORTED_SORT_TYPE);
         }
 
         TalkBoxInfoPair talkBoxInfoPair = getTalkBoxInfoPair(itemPage.getContent());

--- a/src/main/java/com/influy/domain/item/service/ItemServiceImpl.java
+++ b/src/main/java/com/influy/domain/item/service/ItemServiceImpl.java
@@ -110,8 +110,6 @@ public class ItemServiceImpl implements ItemService {
                 request.getRegularPrice(), request.getSalePrice(), request.getMarketLink() , request.getItemPeriod(), request.getComment(), request.getIsArchived(),
                 request.getStatus(), request.getIsDateUndefined());
 
-        if (!request.getIsArchived() && request.getIsDateUndefined()) throw new GeneralException(ErrorStatus.ITEM_INFO_REQUIRED);
-
         if (request.getItemImgList() != null) {
             item.getImageList().clear();
             createItemImgList(request, item);

--- a/src/main/java/com/influy/domain/item/service/ItemServiceImpl.java
+++ b/src/main/java/com/influy/domain/item/service/ItemServiceImpl.java
@@ -206,25 +206,18 @@ public class ItemServiceImpl implements ItemService {
             // 보관 상품 아닌 것 중에서 진행 중 상품 필터 미적용
             if (sortType == ItemSortType.END_DATE) {
                 // 마감일 빠른 순 -> endDate = null -> endDate < now
-                itemPage = itemRepository.findAllSortedByEndDate(sellerId, LocalDateTime.now(), isArchived, pageable);
+                itemPage = itemRepository.findAllSortedByEndDate(sellerId, LocalDateTime.now(), false, pageable);
             } else {
                 // sortType == ItemSortType.CREATE_DATE
                 // 최신 생성 순 -> endDate = null -> endDate < now
-                itemPage = itemRepository.findAllSortedByCreatedAt(sellerId, LocalDateTime.now(), isArchived, pageable);
-            }
-        } else if (isOnGoing) {
-            // isArchived && isOnGoing 보관 상품인 것 중에서 진행 중 상품 필터 적용
-            if (sortType == ItemSortType.END_DATE) {
-                itemPage= itemRepository.findOngoingItemsSortedByEndDate(sellerId, LocalDateTime.now(), isArchived, pageable);
-            } else {
-                itemPage = itemRepository.findOngoingItemsSortedByCreatedAt(sellerId, LocalDateTime.now(), isArchived, pageable);
+                itemPage = itemRepository.findAllSortedByCreatedAt(sellerId, LocalDateTime.now(), false, pageable);
             }
         } else {
-            // isArchived && !isOnGoing 보관 상품인 것 중에서 진행 중 상품 필터 미적용
+            // 보관 상품 (진행 중 상품 필터 없음)
             if (sortType == ItemSortType.END_DATE) {
-                itemPage = itemRepository.findAllSortedByEndDate(sellerId, LocalDateTime.now(), isArchived, pageable);
+                itemPage = itemRepository.findAllSortedByEndDate(sellerId, LocalDateTime.now(), true, pageable);
             } else {
-                itemPage = itemRepository.findAllSortedByCreatedAt(sellerId, LocalDateTime.now(), isArchived, pageable);
+                itemPage = itemRepository.findAllSortedByCreatedAt(sellerId, LocalDateTime.now(), true, pageable);
             }
         }
 

--- a/src/main/java/com/influy/domain/item/service/ItemServiceImpl.java
+++ b/src/main/java/com/influy/domain/item/service/ItemServiceImpl.java
@@ -173,7 +173,10 @@ public class ItemServiceImpl implements ItemService {
                     .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
             if (member.getRole() == MemberRole.USER) memberRole = MemberRole.USER;
             likeItems = likeRepository.findLikedItemIdsByMember(member);
+
         }
+
+        if (isArchived && (memberRole == MemberRole.USER || userDetails == null)) throw new GeneralException(ErrorStatus.NOT_OWNER);
 
         SellerProfile seller = sellerRepository.findById(sellerId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.SELLER_NOT_FOUND));
@@ -194,20 +197,37 @@ public class ItemServiceImpl implements ItemService {
 
         if (!isArchived & isOnGoing) {
             // 보관 상품 아닌 것 중에서 진행 중 상품 필터 적용
-            itemPage = itemRepository.findOngoingItems(sellerId, LocalDateTime.now(), pageable);
+            if (sortType == ItemSortType.END_DATE) {
+                // 마감일 빠른 순 -> endDate = null
+                itemPage= itemRepository.findOngoingItemsSortedByEndDate(sellerId, LocalDateTime.now(), isArchived, pageable);
+            } else {
+                // 최신 생성 순
+                itemPage = itemRepository.findOngoingItemsSortedByCreatedAt(sellerId, LocalDateTime.now(), isArchived, pageable);
+            }
         } else if (!isArchived & !isOnGoing) {
             // 보관 상품 아닌 것 중에서 진행 중 상품 필터 미적용
             if (sortType == ItemSortType.END_DATE) {
                 // 마감일 빠른 순 -> endDate = null -> endDate < now
-                itemPage = itemRepository.findAllSortedByEndDate(sellerId, LocalDateTime.now(), pageable);
+                itemPage = itemRepository.findAllSortedByEndDate(sellerId, LocalDateTime.now(), isArchived, pageable);
             } else {
                 // sortType == ItemSortType.CREATE_DATE
                 // 최신 생성 순 -> endDate = null -> endDate < now
-                itemPage = itemRepository.findAllSortedByCreatedAt(sellerId, LocalDateTime.now(), pageable);
+                itemPage = itemRepository.findAllSortedByCreatedAt(sellerId, LocalDateTime.now(), isArchived, pageable);
+            }
+        } else if (isOnGoing) {
+            // isArchived && isOnGoing 보관 상품인 것 중에서 진행 중 상품 필터 적용
+            if (sortType == ItemSortType.END_DATE) {
+                itemPage= itemRepository.findOngoingItemsSortedByEndDate(sellerId, LocalDateTime.now(), isArchived, pageable);
+            } else {
+                itemPage = itemRepository.findOngoingItemsSortedByCreatedAt(sellerId, LocalDateTime.now(), isArchived, pageable);
             }
         } else {
-            // 보관 상품
-            itemPage = itemRepository.findBySellerIdAndIsArchivedTrue(sellerId, pageable);
+            // isArchived && !isOnGoing 보관 상품인 것 중에서 진행 중 상품 필터 미적용
+            if (sortType == ItemSortType.END_DATE) {
+                itemPage = itemRepository.findAllSortedByEndDate(sellerId, LocalDateTime.now(), isArchived, pageable);
+            } else {
+                itemPage = itemRepository.findAllSortedByCreatedAt(sellerId, LocalDateTime.now(), isArchived, pageable);
+            }
         }
 
         TalkBoxInfoPair talkBoxInfoPair = getTalkBoxInfoPair(itemPage.getContent());

--- a/src/main/java/com/influy/domain/sellerProfile/controller/SellerProfileController.java
+++ b/src/main/java/com/influy/domain/sellerProfile/controller/SellerProfileController.java
@@ -1,5 +1,6 @@
 package com.influy.domain.sellerProfile.controller;
 
+import com.influy.domain.home.dto.HomeResponseDto;
 import com.influy.domain.item.dto.jpql.ItemJPQLResponse.IsArchivedItemCount;
 import com.influy.domain.item.service.ItemService;
 import com.influy.domain.member.entity.Member;
@@ -114,6 +115,12 @@ public class SellerProfileController {
         SellerProfileResponseDTO.IsPublic body = SellerProfileConverter.toIsPublicDTO(sellerService.updateIsPublic(seller,status));
 
         return ApiResponse.onSuccess(body);
+    }
+
+    @GetMapping("seller/{sellerId}/overview")
+    @Operation(summary = "셀러 오버뷰 정보")
+    public ApiResponse<HomeResponseDto.SellerThumbnailDto> getOverview(@RequestParam("sellerId") Long sellerId) {
+        return ApiResponse.onSuccess(sellerService.getOverview(sellerId));
     }
 
 }

--- a/src/main/java/com/influy/domain/sellerProfile/service/SellerProfileService.java
+++ b/src/main/java/com/influy/domain/sellerProfile/service/SellerProfileService.java
@@ -1,5 +1,6 @@
 package com.influy.domain.sellerProfile.service;
 
+import com.influy.domain.home.dto.HomeResponseDto;
 import com.influy.domain.item.dto.jpql.ItemJPQLResponse.IsArchivedItemCount;
 import com.influy.domain.member.dto.MemberRequestDTO;
 import com.influy.domain.member.entity.Member;
@@ -26,4 +27,6 @@ public interface SellerProfileService {
     List<IsArchivedItemCount> getMarketItems(Long sellerId);
 
     Boolean checkQuestionOwner(Long tagId, Long categoryId, Long sellerId);
+
+    HomeResponseDto.SellerThumbnailDto getOverview(Long sellerId);
 }

--- a/src/main/java/com/influy/domain/sellerProfile/service/SellerProfileServiceImpl.java
+++ b/src/main/java/com/influy/domain/sellerProfile/service/SellerProfileServiceImpl.java
@@ -1,5 +1,7 @@
 package com.influy.domain.sellerProfile.service;
 
+import com.influy.domain.home.converter.HomeConverter;
+import com.influy.domain.home.dto.HomeResponseDto;
 import com.influy.domain.item.dto.jpql.ItemJPQLResponse.IsArchivedItemCount;
 import com.influy.domain.item.repository.ItemRepository;
 import com.influy.domain.like.entity.LikeStatus;
@@ -91,5 +93,12 @@ public class SellerProfileServiceImpl implements SellerProfileService {
         }else return false;
 
         return true;
+    }
+
+    @Override
+    public HomeResponseDto.SellerThumbnailDto getOverview(Long sellerId) {
+        SellerProfile seller = sellerProfileRepository.findById(sellerId)
+                .orElseThrow(()->new GeneralException(ErrorStatus.SELLER_NOT_FOUND));
+        return HomeConverter.toSellerThumbnailDto(seller);
     }
 }

--- a/src/main/java/com/influy/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/influy/global/apiPayload/code/status/ErrorStatus.java
@@ -63,6 +63,7 @@ public enum ErrorStatus implements BaseCode {
     ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "ITEM NOT FOUND", "아이템을 찾을 수 없습니다."),
     UNMATCHED_SELLER_ITEM(HttpStatus.BAD_REQUEST, "UNMATCHED SELLER ITEM", "셀러가 해당 아이템을 가지고 있지 않습니다."),
     UNMATCHED_ITEM_FAQCATEGORY(HttpStatus.BAD_REQUEST, "UNMATCHED ITEM FAQCATEGORY", "아이템이 해당 FAQ 카테고리를 가지고 있지 않습니다."),
+    ITEM_INFO_REQUIRED(HttpStatus.BAD_REQUEST, "ITEM INFO REQUIRED", "아이템 정보가 더 필요합니다."),
 
     //질문관리창 관련 응당
     QUESTION_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "QUESTION CATEGORY NOT FOUND", "질문 카테고리를 찾을 수 없습니다."),


### PR DESCRIPTION
## 💜 Related Issue

> #64

## 💜 Work Details

- [x] 아이템 엔티티에 isDateUndefined 추가 & 필수 아닌 필드에 builder.default 추가
- [x] 아이템 조회 관련 응답에 status, isDateUndefined 추가
- [x] 아이템 리스트 조회 정렬 세부 순서 수정
- [x] 개별 셀러 썸네일 조회 api 구현
- [x] 아이템 세부내용 조회에서 아이템 카테고리 리스트 id 리스트로 주도록 수정
- [x] 아이템 리스트 조회 정렬에서 endDate 없을 경우 처리
- [x] 아이템 보관 경우도 진행중인 상품만 보기 선택 추가 

## 💜 Review Requirement

> 모두 테스트 완료했슴니당
