### PR TITLE
회원 탈퇴, 수정 시 s3 이미지 삭제 로직 추가

### DIFF
--- a/src/main/java/com/influy/domain/item/repository/ItemRepository.java
+++ b/src/main/java/com/influy/domain/item/repository/ItemRepository.java
@@ -131,4 +131,11 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
     """)
     List<ItemJPQLResponse.ItemWithSellerInfo> findAllWithSellerInfoById(@Param("itemIds") List<Long> itemIds);
 
+    @Query(value = """
+    SELECT ii.image_url
+    FROM item i
+    JOIN item_image ii on ii.item_id = i.id
+    WHERE i.seller_id = :sellerId
+    """, nativeQuery = true)
+    List<String> findAllItemImagesBySellerId(@Param("sellerId") Long sellerId);
 }

--- a/src/main/java/com/influy/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/influy/domain/member/service/MemberServiceImpl.java
@@ -2,6 +2,8 @@ package com.influy.domain.member.service;
 
 import com.influy.domain.category.entity.Category;
 import com.influy.domain.category.repository.CategoryRepository;
+import com.influy.domain.image.service.ImageService;
+import com.influy.domain.item.repository.ItemRepository;
 import com.influy.domain.member.converter.MemberConverter;
 import com.influy.domain.member.dto.MemberRequestDTO;
 import com.influy.domain.member.entity.Member;
@@ -25,6 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -36,6 +39,8 @@ public class MemberServiceImpl implements MemberService {
     private final SellerProfileRepository sellerProfileRepository;
     private final AuthService authService;
     private final CategoryRepository categoryRepository;
+    private final ImageService imageService;
+    private final ItemRepository itemRepository;
 
     @Override
     public Member findByKakaoId(Long kakaoId) {
@@ -108,12 +113,38 @@ public class MemberServiceImpl implements MemberService {
     @Override
     @Transactional
     public void deleteMember(Member member) {
+
+        List<String> images = new ArrayList<>();
+        if(member.getProfileImg()!=null){
+            images.add(member.getProfileImg());
+        }
+
+
+        if(member.getSellerProfile()!=null){
+            SellerProfile seller = member.getSellerProfile();
+            if(seller.getBackgroundImg()!=null) images.add(seller.getBackgroundImg());
+            images.addAll(itemRepository.findAllItemImagesBySellerId(seller.getId()));
+        }
+
+        //관련 이미지 먼저 삭제
+        if(!images.isEmpty()){
+            imageService.deleteImg(images);
+        }
+
+
+
         memberRepository.delete(member);
     }
 
     @Override
     @Transactional
     public Member updateMemeber(Member member, MemberRequestDTO.UpdateProfile request) {
+
+        //변경이 생기면 기존 이미지 삭제
+        if(!Objects.equals(request.getProfileUrl(),member.getProfileImg())){
+            String img = member.getProfileImg();
+            if(img!=null) imageService.deleteImg(new ArrayList<>(List.of(member.getProfileImg())));
+        }
 
         return member.updateProfile(request);
     }

--- a/src/main/java/com/influy/domain/sellerProfile/service/SellerProfileServiceImpl.java
+++ b/src/main/java/com/influy/domain/sellerProfile/service/SellerProfileServiceImpl.java
@@ -2,6 +2,7 @@ package com.influy.domain.sellerProfile.service;
 
 import com.influy.domain.home.converter.HomeConverter;
 import com.influy.domain.home.dto.HomeResponseDto;
+import com.influy.domain.image.service.ImageService;
 import com.influy.domain.item.dto.jpql.ItemJPQLResponse.IsArchivedItemCount;
 import com.influy.domain.item.repository.ItemRepository;
 import com.influy.domain.like.entity.LikeStatus;
@@ -19,7 +20,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @Service
 @Transactional(readOnly = true)
@@ -29,6 +32,7 @@ public class SellerProfileServiceImpl implements SellerProfileService {
     private final ItemRepository itemRepository;
     private final SellerProfileRepository sellerProfileRepository;
     private final LikeRepository likeRepository;
+    private final ImageService imageService;
 
     public SellerProfile getSellerProfile(Long sellerId){
         return sellerProfileRepository.findById(sellerId).orElseThrow(()->new GeneralException(ErrorStatus.SELLER_NOT_FOUND));
@@ -37,10 +41,29 @@ public class SellerProfileServiceImpl implements SellerProfileService {
     @Override
     @Transactional
     public SellerProfile updateSeller(SellerProfile sellerProfile, SellerProfileRequestDTO.UpdateProfile request) {
+
+        List<String> images = new ArrayList<>();
+
         if(request.getProfile()!=null){
             Member member = sellerProfile.getMember();
+            //프사 변경 검사
+            if(!Objects.equals(request.getProfile().getProfileUrl(),member.getProfileImg())){
+                String img = member.getProfileImg();
+                if(img!=null) images.add(img);
+            }
             member.updateProfile(request.getProfile());
         }
+
+        //배경사진 변경 검사
+        if(!Objects.equals(request.getBackgroundImg(),sellerProfile.getBackgroundImg())){
+            String bgImg = sellerProfile.getBackgroundImg();
+            if(bgImg!=null) images.add(bgImg);
+        }
+
+        if(!images.isEmpty()){
+            imageService.deleteImg(images);
+        }
+
         return sellerProfile.setProfile(request);
     }
 


### PR DESCRIPTION
## 💜 Related Issue

> #64

## 💜 Work Details

- [x] 회원 탈퇴 시 프사, 배사, 아이템 사진들 모두 삭제
- [x] 회원 정보 수정 시 프사/배사가 현재와 다를 시 삭제 후 업데이트

## 💜 Review Requirement

> 궁금한 사항
