### PR TITLE
#64 refactor : 공지 리스트 조회 시 최상단 공지를 첫번째로 제공

### DIFF
--- a/src/main/java/com/influy/domain/announcement/repository/AnnouncementRepository.java
+++ b/src/main/java/com/influy/domain/announcement/repository/AnnouncementRepository.java
@@ -5,6 +5,9 @@ import com.influy.domain.sellerProfile.entity.SellerProfile;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -16,4 +19,12 @@ public interface AnnouncementRepository extends JpaRepository<Announcement, Long
     Optional<Announcement> findFirstBySellerOrderByCreatedAtDesc(SellerProfile seller);
 
     Integer countBySeller(SellerProfile seller);
+
+    @Query("""
+    SELECT a
+    FROM Announcement a
+    WHERE a.seller = :seller
+    ORDER BY a.isPrimary DESC, a.createdAt DESC
+    """)
+    Page<Announcement> findAllBySellerWithPrimaryFirst(@Param("seller") SellerProfile seller, Pageable pageable);
 }

--- a/src/main/java/com/influy/domain/announcement/service/AnnouncementServiceImpl.java
+++ b/src/main/java/com/influy/domain/announcement/service/AnnouncementServiceImpl.java
@@ -32,7 +32,7 @@ public class AnnouncementServiceImpl implements AnnouncementService {
         Pageable pageable = page.toPageable(sort);
 
         SellerProfile seller = sellerService.getSellerProfile(sellerId);
-        return announcementRepository.findAllBySeller(seller,pageable);
+        return announcementRepository.findAllBySellerWithPrimaryFirst(seller,pageable);
     }
 
     //공지 추가
@@ -43,6 +43,7 @@ public class AnnouncementServiceImpl implements AnnouncementService {
             throw new GeneralException(ErrorStatus.BAD_REQUEST);
         }
         Announcement announcement = AnnouncementConverter.toEntity(requestDTO,seller);
+        seller.getAnnouncementList().add(announcement);
 
         return announcementRepository.save(announcement);
 


### PR DESCRIPTION
## 💜 Related Issue

> #64 

## 💜 Work Details

> 프론트에서 일반 공지 리스트에서도 최상단 공지를 맨 위로 올려달라고 해서 수정합니다.

## 💜 Review Requirement

> 궁금한 사항
