### PR TITLE
#64 feat : 계정 설정 시 기본 정보 조회 용 api 구현

### DIFF
--- a/src/main/java/com/influy/domain/member/controller/MemberController.java
+++ b/src/main/java/com/influy/domain/member/controller/MemberController.java
@@ -8,6 +8,7 @@ import com.influy.domain.member.dto.MemberResponseDTO;
 import com.influy.domain.member.entity.Member;
 import com.influy.domain.member.entity.MemberRole;
 import com.influy.domain.member.service.MemberService;
+import com.influy.domain.sellerProfile.dto.SellerProfileResponseDTO;
 import com.influy.domain.sellerProfile.entity.SellerProfile;
 import com.influy.global.apiPayload.ApiResponse;
 import com.influy.global.apiPayload.code.BaseCode;
@@ -166,6 +167,18 @@ public class MemberController {
             return ApiResponse.onSuccess(ErrorStatus.USERNAME_ALREADY_EXISTS);
         }
         return ApiResponse.onSuccess(SuccessStatus.NO_DUPLICATE_ROW);
+
+    }
+
+    @GetMapping("/setting")
+    @Operation(summary = "계정 설정 시 기본 정보", description = "마켓을 가진 사용자의 경우에는 셀러 프로필 공개 여부도 함께 제공")
+    public ApiResponse<MemberResponseDTO.Setting> getSettingProfile(@AuthenticationPrincipal CustomUserDetails userDetails){
+
+
+        Member member = memberService.findById(userDetails.getId());
+        MemberResponseDTO.Setting body = MemberConverter.toSettingDTO(member);
+
+        return ApiResponse.onSuccess(body);
 
     }
 

--- a/src/main/java/com/influy/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/influy/domain/member/converter/MemberConverter.java
@@ -5,8 +5,12 @@ import com.influy.domain.member.dto.MemberRequestDTO;
 import com.influy.domain.member.dto.MemberResponseDTO;
 import com.influy.domain.member.entity.Member;
 import com.influy.domain.member.entity.MemberRole;
+import com.influy.domain.sellerProfile.dto.SellerProfileResponseDTO;
+import com.influy.global.apiPayload.code.status.ErrorStatus;
+import com.influy.global.apiPayload.exception.GeneralException;
 
 import java.util.List;
+import java.util.Objects;
 
 public class MemberConverter {
     public static Member toMember(MemberRequestDTO.UserJoin requestDTO, MemberRole role, String kakaoNickname) {
@@ -38,4 +42,16 @@ public class MemberConverter {
                 .build();
     }
 
+    public static MemberResponseDTO.Setting toSettingDTO(Member member) {
+        if(member.getRole()==MemberRole.SELLER||member.getRole()==MemberRole.ADMIN){
+            return SellerProfileResponseDTO.SellerSetting.builder()
+                    .username(member.getUsername())
+                    .isPublic(Objects.requireNonNull(member.getSellerProfile(), "셀러 프로필이 없습니다.").getIsPublic())
+                    .build();
+        }else{
+            return MemberResponseDTO.MemberSetting.builder()
+                    .username(member.getUsername())
+                    .build();
+        }
+    }
 }

--- a/src/main/java/com/influy/domain/member/dto/MemberResponseDTO.java
+++ b/src/main/java/com/influy/domain/member/dto/MemberResponseDTO.java
@@ -1,5 +1,6 @@
 package com.influy.domain.member.dto;
 
+import com.influy.domain.sellerProfile.dto.SellerProfileResponseDTO;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
@@ -27,4 +28,14 @@ public class MemberResponseDTO {
         private LocalDateTime createdAt;
     }
 
+    public interface Setting{};
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class MemberSetting implements Setting{
+        @Schema(description = "유저 아이디", example = "crazy_dog")
+        private String username;
+    }
 }

--- a/src/main/java/com/influy/domain/member/service/MemberService.java
+++ b/src/main/java/com/influy/domain/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.influy.domain.member.service;
 
 import com.influy.domain.member.dto.MemberRequestDTO;
+import com.influy.domain.member.dto.MemberResponseDTO;
 import com.influy.domain.member.entity.Member;
 import com.influy.domain.member.entity.MemberRole;
 import com.influy.domain.questionCategory.entity.QuestionCategory;

--- a/src/main/java/com/influy/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/influy/domain/member/service/MemberServiceImpl.java
@@ -6,6 +6,7 @@ import com.influy.domain.image.service.ImageService;
 import com.influy.domain.item.repository.ItemRepository;
 import com.influy.domain.member.converter.MemberConverter;
 import com.influy.domain.member.dto.MemberRequestDTO;
+import com.influy.domain.member.dto.MemberResponseDTO;
 import com.influy.domain.member.entity.Member;
 import com.influy.domain.member.entity.MemberRole;
 import com.influy.domain.member.repository.MemberRepository;
@@ -172,5 +173,7 @@ public class MemberServiceImpl implements MemberService {
             throw new GeneralException(ErrorStatus.SELLER_REQUIRED);
         }
     }
+
+
 
 }

--- a/src/main/java/com/influy/domain/sellerProfile/dto/SellerProfileResponseDTO.java
+++ b/src/main/java/com/influy/domain/sellerProfile/dto/SellerProfileResponseDTO.java
@@ -1,5 +1,6 @@
 package com.influy.domain.sellerProfile.dto;
 
+import com.influy.domain.member.dto.MemberResponseDTO;
 import com.influy.domain.sellerProfile.entity.ItemSortType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
@@ -67,5 +68,16 @@ public class SellerProfileResponseDTO {
         private Long sellerId;
         @Schema(description = "공개 여부", example = "false")
         private Boolean isPublic;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class SellerSetting implements MemberResponseDTO.Setting{
+        @Schema(description = "유저 아이디", example = "crazy_dog")
+        private String username;
+        @Schema(description = "셀러 마켓 공개 여부", example = "true")
+        private boolean isPublic;
     }
 }


### PR DESCRIPTION
## 💜 Related Issue

> #이슈번호

## 💜 Work Details

> 계정 설정 시 기존 값 조회 용 api입니다.
<img width="449" height="591" alt="image" src="https://github.com/user-attachments/assets/29ba0ecd-133c-4939-8bd6-fc977eb21748" />

- 셀러의 경우 셀러 프로필 공개 여부를 함께 제공하고 일반 회원이나 매니저의 경우에는 유저네임만 제공합니다.

## 💜 Review Requirement

> 궁금한 사항
