### PR TITLE
Question 멤버 유저네임, 셀러 아이디 추가

### DIFF
--- a/src/main/java/com/influy/domain/item/dto/jpql/ItemJPQLResponse.java
+++ b/src/main/java/com/influy/domain/item/dto/jpql/ItemJPQLResponse.java
@@ -25,6 +25,7 @@ public class ItemJPQLResponse {
         Long getItemId();
         String getItemTitle();
         String getItemMainImg();
+        Long getSellerId();
         String getSellerNickname();
         String getSellerProfileImg();
 

--- a/src/main/java/com/influy/domain/item/repository/ItemRepository.java
+++ b/src/main/java/com/influy/domain/item/repository/ItemRepository.java
@@ -127,7 +127,7 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
     Page<Item> findOngoingItemsSortedByCreatedAt(@Param("sellerId") Long sellerId, @Param("now") LocalDateTime now, @Param("isArchived") Boolean isArchived, Pageable pageable);
     
     @Query("""
-    SELECT i.id AS itemId, i.name AS itemTitle, i.mainImg AS itemMainImg, m.nickname AS sellerNickname, m.profileImg AS sellerProfileImg
+    SELECT i.id AS itemId, i.name AS itemTitle, i.mainImg AS itemMainImg, s.id AS sellerId, m.nickname AS sellerNickname, m.profileImg AS sellerProfileImg
     FROM Item i
     JOIN SellerProfile s ON i.seller = s
     JOIN Member m ON s.member = m

--- a/src/main/java/com/influy/domain/question/converter/QuestionConverter.java
+++ b/src/main/java/com/influy/domain/question/converter/QuestionConverter.java
@@ -82,23 +82,24 @@ public class QuestionConverter {
                 .build();
     }
 
-    public static QuestionResponseDTO.UserViewQNA toUserViewDTO(AnswerJPQLResult.UserViewQNAInfo question) {
+    public static QuestionResponseDTO.UserViewQNA toUserViewDTO(AnswerJPQLResult.UserViewQNAInfo question, String username) {
         return QuestionResponseDTO.UserViewQuestion.builder()
                 .type(question.getType())
                 .id(question.getId())
                 .categoryName(question.getCategoryName())
                 .content(question.getContent())
                 .createdAt(question.getCreatedAt())
+                .username(username)
                 .build();
     }
 
     public static QuestionResponseDTO.UserViewQNAPage toUserViewQNAPage(Page<AnswerJPQLResult.UserViewQNAInfo> userQNAList,
-                                                                        String greeting) {
+                                                                        String greeting, String username) {
         List<QuestionResponseDTO.UserViewQNA> content = new ArrayList<>(userQNAList != null ?
                 userQNAList.getContent().stream().map(
                         qna -> {
                             if (qna.getType().equals("Q")) {
-                                return toUserViewDTO(qna);
+                                return toUserViewDTO(qna, username);
                             } else {
                                 return AnswerConverter.toUserViewDTO(qna);
                             }

--- a/src/main/java/com/influy/domain/question/converter/QuestionConverter.java
+++ b/src/main/java/com/influy/domain/question/converter/QuestionConverter.java
@@ -180,6 +180,7 @@ public class QuestionConverter {
                 .itemId(itemSeller.getItemId())
                 .itemTitle(itemSeller.getItemTitle())
                 .itemMainPic(itemSeller.getItemMainImg())
+                .sellerId(itemSeller.getSellerId())
                 .sellerNickname(itemSeller.getSellerNickname())
                 .sellerProfilePic(itemSeller.getSellerProfileImg())
                 .lastChatContent(lastChatContent)

--- a/src/main/java/com/influy/domain/question/dto/QuestionResponseDTO.java
+++ b/src/main/java/com/influy/domain/question/dto/QuestionResponseDTO.java
@@ -45,6 +45,8 @@ public class QuestionResponseDTO {
         private String content;
         @Schema(description = "생성 일자", example = "2025-01-03Z13:13:13")
         private LocalDateTime createdAt;
+        @Schema(description = "작성자 username", example = "crazy_dog")
+        private String username;
     }
 
     @Builder

--- a/src/main/java/com/influy/domain/question/dto/QuestionResponseDTO.java
+++ b/src/main/java/com/influy/domain/question/dto/QuestionResponseDTO.java
@@ -192,7 +192,9 @@ public class QuestionResponseDTO {
         private String itemTitle;
         @Schema(description = "해당 톡박스 아이템 대표 사진", example="http:/amazon.s3~")
         private String itemMainPic;
-        @Schema(description = "아이템 셀러 닉네임", example="소현소현")
+        @Schema(description = "아이템 셀러 아이디", example = "1")
+        private Long sellerId;
+        @Schema(description = "셀러 닉네임", example="소현소현")
         private String sellerNickname;
         @Schema(description = "셀러 프로필 사진", example="http://amazon.s3~")
         private String sellerProfilePic;

--- a/src/main/java/com/influy/domain/question/service/QuestionServiceImpl.java
+++ b/src/main/java/com/influy/domain/question/service/QuestionServiceImpl.java
@@ -98,7 +98,8 @@ public class QuestionServiceImpl implements QuestionService {
             greeting = item.getTalkBoxComment();
         }
 
-        return QuestionConverter.toUserViewQNAPage(userQNAList, greeting);
+        String username = memberService.findById(memberId).getUsername();
+        return QuestionConverter.toUserViewQNAPage(userQNAList, greeting, username);
     }
 
     @Override


### PR DESCRIPTION
## 💜 Related Issue

> #64 

## 💜 Work Details

> 

- [ ] 톡박스 리스트 항목에 각 톡박스별 셀러 아이디 추가
- [ ] 톡박스 내용 중 질문에 질문자 유저네임 추가

## 💜 Review Requirement

> 질문자 유저네임 같은 경우는 데모데이 후에 프론트에 로그인한 사용자 정보 전역관리 하는게 어떤지 물어보고 다시 빼든지 유지하든지 해야할 것 같습니다.